### PR TITLE
IaM 연동

### DIFF
--- a/be/build.gradle.kts
+++ b/be/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
 
     // oauth2
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server") // JWT 검증용
 
     // Spring AI
     implementation("org.springframework.ai:spring-ai-starter-model-openai") // OpenAI -> Gemini API 사용 가능 

--- a/be/build.gradle.kts
+++ b/be/build.gradle.kts
@@ -35,8 +35,11 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
     // Security & Validation
-    // implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    // oauth2
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
     // Spring AI
     implementation("org.springframework.ai:spring-ai-starter-model-openai") // OpenAI -> Gemini API 사용 가능 

--- a/be/src/main/java/io/hlab/OpenConsole/api/role/RoleController.java
+++ b/be/src/main/java/io/hlab/OpenConsole/api/role/RoleController.java
@@ -48,7 +48,6 @@ public class RoleController {
      * ADMIN 권한 필요
      */
     @DeleteMapping
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasRole('ADMIN')")
     public ApiResponse<Void> removeRole(
             @RequestParam @jakarta.validation.constraints.Email String email,

--- a/be/src/main/java/io/hlab/OpenConsole/api/role/RoleController.java
+++ b/be/src/main/java/io/hlab/OpenConsole/api/role/RoleController.java
@@ -4,7 +4,6 @@ import io.hlab.OpenConsole.api.role.dto.RoleAssignRequest;
 import io.hlab.OpenConsole.api.role.dto.RoleResponse;
 import io.hlab.OpenConsole.application.role.RoleService;
 import io.hlab.OpenConsole.common.dto.ApiResponse;
-import io.hlab.OpenConsole.infrastructure.iam.IamException;
 import io.hlab.OpenConsole.infrastructure.iam.IamRole;
 import io.hlab.OpenConsole.infrastructure.security.JwtUtils;
 import jakarta.servlet.http.HttpServletRequest;
@@ -40,13 +39,8 @@ public class RoleController {
     public ApiResponse<Void> assignRole(
             @RequestBody @Valid RoleAssignRequest request,
             HttpServletRequest httpRequest) {
-        try {
-            roleService.assignRoles(request.getEmail(), request.getRoles());
-            return ApiResponse.success("Role이 부여되었습니다.", null);
-        } catch (IamException e) {
-            log.error("Role 부여 실패: email={}, roles={}", request.getEmail(), request.getRoles(), e);
-            return ApiResponse.error("ROLE_ASSIGN_FAILED", "Role 부여에 실패했습니다: " + e.getMessage());
-        }
+        roleService.assignRoles(request.getEmail(), request.getRoles());
+        return ApiResponse.success("Role이 부여되었습니다.", null);
     }
 
     /**
@@ -59,13 +53,8 @@ public class RoleController {
     public ApiResponse<Void> removeRole(
             @RequestParam @jakarta.validation.constraints.Email String email,
             @RequestParam IamRole role) {
-        try {
-            roleService.removeRole(email, role);
-            return ApiResponse.success("Role이 제거되었습니다.", null);
-        } catch (IamException e) {
-            log.error("Role 제거 실패: email={}, role={}", email, role, e);
-            return ApiResponse.error("ROLE_REMOVE_FAILED", "Role 제거에 실패했습니다: " + e.getMessage());
-        }
+        roleService.removeRole(email, role);
+        return ApiResponse.success("Role이 제거되었습니다.", null);
     }
 
     /**
@@ -77,14 +66,9 @@ public class RoleController {
     public ApiResponse<RoleResponse> getUserRoles(
             @RequestParam @jakarta.validation.constraints.Email String email,
             HttpServletRequest httpRequest) {
-        try {
-            List<IamRole> roles = roleService.getUserRoles(email);
-            RoleResponse response = RoleResponse.of(email, roles);
-            return ApiResponse.success(response);
-        } catch (IamException e) {
-            log.error("Role 조회 실패: email={}", email, e);
-            return ApiResponse.error("ROLE_QUERY_FAILED", "Role 조회에 실패했습니다: " + e.getMessage());
-        }
+        List<IamRole> roles = roleService.getUserRoles(email);
+        RoleResponse response = RoleResponse.of(email, roles);
+        return ApiResponse.success(response);
     }
 
     /**

--- a/be/src/main/java/io/hlab/OpenConsole/api/role/RoleController.java
+++ b/be/src/main/java/io/hlab/OpenConsole/api/role/RoleController.java
@@ -1,0 +1,107 @@
+package io.hlab.OpenConsole.api.role;
+
+import io.hlab.OpenConsole.api.role.dto.RoleAssignRequest;
+import io.hlab.OpenConsole.api.role.dto.RoleResponse;
+import io.hlab.OpenConsole.application.role.RoleService;
+import io.hlab.OpenConsole.common.dto.ApiResponse;
+import io.hlab.OpenConsole.infrastructure.iam.IamException;
+import io.hlab.OpenConsole.infrastructure.iam.IamRole;
+import io.hlab.OpenConsole.infrastructure.security.JwtUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * Role 관리 API Controller
+ * 관리자가 사용자의 role을 부여/제거/조회할 수 있는 API
+ */
+@Slf4j
+@RestController
+@RequestMapping("/roles")
+@RequiredArgsConstructor
+public class RoleController {
+
+    private final RoleService roleService;
+    private final JwtUtils jwtUtils;
+
+    /**
+     * 사용자에게 role 부여
+     * ADMIN 권한 필요
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<Void> assignRole(
+            @RequestBody @Valid RoleAssignRequest request,
+            HttpServletRequest httpRequest) {
+        try {
+            roleService.assignRoles(request.getEmail(), request.getRoles());
+            return ApiResponse.success("Role이 부여되었습니다.", null);
+        } catch (IamException e) {
+            log.error("Role 부여 실패: email={}, roles={}", request.getEmail(), request.getRoles(), e);
+            return ApiResponse.error("ROLE_ASSIGN_FAILED", "Role 부여에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 사용자로부터 role 제거
+     * ADMIN 권한 필요
+     */
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<Void> removeRole(
+            @RequestParam @jakarta.validation.constraints.Email String email,
+            @RequestParam IamRole role) {
+        try {
+            roleService.removeRole(email, role);
+            return ApiResponse.success("Role이 제거되었습니다.", null);
+        } catch (IamException e) {
+            log.error("Role 제거 실패: email={}, role={}", email, role, e);
+            return ApiResponse.error("ROLE_REMOVE_FAILED", "Role 제거에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 사용자의 role 목록 조회
+     * ADMIN 권한 필요
+     */
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<RoleResponse> getUserRoles(
+            @RequestParam @jakarta.validation.constraints.Email String email,
+            HttpServletRequest httpRequest) {
+        try {
+            List<IamRole> roles = roleService.getUserRoles(email);
+            RoleResponse response = RoleResponse.of(email, roles);
+            return ApiResponse.success(response);
+        } catch (IamException e) {
+            log.error("Role 조회 실패: email={}", email, e);
+            return ApiResponse.error("ROLE_QUERY_FAILED", "Role 조회에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 현재 로그인한 사용자의 role 목록 조회
+     * 인증된 사용자 모두 접근 가능
+     */
+    @GetMapping("/me")
+    public ApiResponse<RoleResponse> getMyRoles(HttpServletRequest httpRequest) {
+        String email = jwtUtils.getCurrentUserEmail();
+        if (email == null) {
+            log.warn("Email을 가져올 수 없습니다. JWT에 email이 없고 Zitadel Management API 조회도 실패했습니다.");
+            return ApiResponse.error("UNAUTHORIZED", "사용자 정보를 확인할 수 없습니다.");
+        }
+
+        List<IamRole> roles = roleService.getCurrentUserRoles();
+        RoleResponse response = RoleResponse.of(email, roles);
+        return ApiResponse.success(response);
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/api/role/dto/RoleAssignRequest.java
+++ b/be/src/main/java/io/hlab/OpenConsole/api/role/dto/RoleAssignRequest.java
@@ -1,0 +1,22 @@
+package io.hlab.OpenConsole.api.role.dto;
+
+import io.hlab.OpenConsole.infrastructure.iam.IamRole;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * Role 부여 요청 DTO
+ */
+@Getter
+public class RoleAssignRequest {
+    @NotBlank(message = "사용자 이메일은 필수입니다.")
+    @jakarta.validation.constraints.Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;  // 사용자 이메일
+
+    @NotEmpty(message = "Role 목록은 필수입니다.")
+    private List<IamRole> roles;
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/api/role/dto/RoleAssignRequest.java
+++ b/be/src/main/java/io/hlab/OpenConsole/api/role/dto/RoleAssignRequest.java
@@ -18,5 +18,14 @@ public class RoleAssignRequest {
 
     @NotEmpty(message = "Role 목록은 필수입니다.")
     private List<IamRole> roles;
+
+    // 테스트 및 JSON 역직렬화를 위한 setter
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setRoles(List<IamRole> roles) {
+        this.roles = roles;
+    }
 }
 

--- a/be/src/main/java/io/hlab/OpenConsole/api/role/dto/RoleResponse.java
+++ b/be/src/main/java/io/hlab/OpenConsole/api/role/dto/RoleResponse.java
@@ -1,0 +1,25 @@
+package io.hlab.OpenConsole.api.role.dto;
+
+import io.hlab.OpenConsole.infrastructure.iam.IamRole;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * Role 조회 응답 DTO
+ */
+@Getter
+public class RoleResponse {
+    private String email;  // 사용자 이메일
+    private List<IamRole> roles;
+
+    private RoleResponse(String email, List<IamRole> roles) {
+        this.email = email;
+        this.roles = roles;
+    }
+
+    public static RoleResponse of(String email, List<IamRole> roles) {
+        return new RoleResponse(email, roles);
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/api/user/UserController.java
+++ b/be/src/main/java/io/hlab/OpenConsole/api/user/UserController.java
@@ -5,7 +5,6 @@ import io.hlab.OpenConsole.api.user.dto.UserResponse;
 import io.hlab.OpenConsole.api.user.dto.UserUpdateRequest;
 import io.hlab.OpenConsole.application.user.UserService;
 import io.hlab.OpenConsole.common.dto.ApiResponse;
-import io.hlab.OpenConsole.domain.user.IamProvider;
 import io.hlab.OpenConsole.domain.user.User;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -30,8 +29,9 @@ public class UserController {
             return ApiResponse.error("UNAUTHORIZED", "로그인되지 않았습니다.");
         }
         
-        // ZITADEL에서 넘겨준 실제 값들을 확인합니다.
-        Optional<User> user = userService.findUserBySubject(IamProvider.ZITADEL, principal.getSubject());
+        // Email로 사용자 찾기 (IAM이 SSOT이므로 email 사용)
+        String email = principal.getEmail();
+        Optional<User> user = userService.findUserByEmail(email);
         if (user.isEmpty()) {
             return ApiResponse.error("USER_NOT_FOUND", "사용자를 찾을 수 없습니다.");
         }
@@ -45,7 +45,7 @@ public class UserController {
     public ApiResponse<UserResponse> createUser(
             @RequestBody @Valid UserCreateRequest request,
             HttpServletRequest httpRequest) {
-        Long userId = userService.createUser(request.getEmail(), request.getName(), request.getProvider(), request.getSubject());
+        Long userId = userService.createUser(request.getEmail(), request.getName());
         User user = userService.getUser(userId);
         String baseUrl = getBaseUrl(httpRequest);
         String resourcePath = getResourcePath(httpRequest);

--- a/be/src/main/java/io/hlab/OpenConsole/api/user/UserControllerExample.java
+++ b/be/src/main/java/io/hlab/OpenConsole/api/user/UserControllerExample.java
@@ -1,0 +1,43 @@
+package io.hlab.OpenConsole.api.user;
+
+import io.hlab.OpenConsole.infrastructure.iam.IamRole;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Role 기반 권한 체크 예시
+ * 실제 UserController에 적용할 수 있는 예시 코드
+ */
+@RestController
+@RequestMapping("/users/example")
+public class UserControllerExample {
+
+    /**
+     * ADMIN만 접근 가능
+     */
+    @GetMapping("/admin-only")
+    @PreAuthorize("hasRole('ADMIN')")
+    public String adminOnly() {
+        return "관리자 전용 API";
+    }
+
+    /**
+     * ADMIN 또는 USER_A 접근 가능
+     */
+    @GetMapping("/admin-or-user-a")
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER_A')")
+    public String adminOrUserA() {
+        return "관리자 또는 USER_A 접근 가능";
+    }
+
+    /**
+     * 모든 인증된 사용자 접근 가능 (권한 체크 없음)
+     */
+    @GetMapping("/authenticated")
+    public String authenticated() {
+        return "인증된 사용자 접근 가능";
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/api/user/dto/UserCreateRequest.java
+++ b/be/src/main/java/io/hlab/OpenConsole/api/user/dto/UserCreateRequest.java
@@ -1,13 +1,14 @@
 package io.hlab.OpenConsole.api.user.dto;
 
-import io.hlab.OpenConsole.domain.user.IamProvider;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.EnumType;
 
+/**
+ * 사용자 생성 요청 DTO
+ * IAM 정보(provider, subject)는 저장하지 않음 (IAM이 SSOT)
+ */
 @Getter
 public class UserCreateRequest {
     @NotBlank(message = "이메일은 필수입니다.")
@@ -18,13 +19,5 @@ public class UserCreateRequest {
     @NotBlank(message = "이름은 필수입니다.")
     @Size(max = 50, message = "이름은 50자 이하여야 합니다.")
     private String name;
-
-    @NotBlank(message = "IAM 공급자는 필수입니다.")
-    @Enumerated(EnumType.STRING)
-    private IamProvider provider;
-
-    @NotBlank(message = "IAM 고유 식별자는 필수입니다.")
-    @Size(max = 100, message = "IAM 고유 식별자는 100자 이하여야 합니다.")
-    private String subject;
 }
 

--- a/be/src/main/java/io/hlab/OpenConsole/api/user/dto/UserCreateRequest.java
+++ b/be/src/main/java/io/hlab/OpenConsole/api/user/dto/UserCreateRequest.java
@@ -1,9 +1,12 @@
 package io.hlab.OpenConsole.api.user.dto;
 
+import io.hlab.OpenConsole.domain.user.IamProvider;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
 
 @Getter
 public class UserCreateRequest {
@@ -15,5 +18,13 @@ public class UserCreateRequest {
     @NotBlank(message = "이름은 필수입니다.")
     @Size(max = 50, message = "이름은 50자 이하여야 합니다.")
     private String name;
+
+    @NotBlank(message = "IAM 공급자는 필수입니다.")
+    @Enumerated(EnumType.STRING)
+    private IamProvider provider;
+
+    @NotBlank(message = "IAM 고유 식별자는 필수입니다.")
+    @Size(max = 100, message = "IAM 고유 식별자는 100자 이하여야 합니다.")
+    private String subject;
 }
 

--- a/be/src/main/java/io/hlab/OpenConsole/application/role/RoleService.java
+++ b/be/src/main/java/io/hlab/OpenConsole/application/role/RoleService.java
@@ -1,0 +1,99 @@
+package io.hlab.OpenConsole.application.role;
+
+import io.hlab.OpenConsole.infrastructure.iam.IamClient;
+import io.hlab.OpenConsole.infrastructure.iam.IamException;
+import io.hlab.OpenConsole.infrastructure.iam.IamRole;
+import io.hlab.OpenConsole.infrastructure.security.JwtUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Role 관리 서비스
+ * IAM 시스템에서 사용자의 role을 부여/제거/조회
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RoleService {
+
+    private final IamClient iamClient;
+    private final JwtUtils jwtUtils;
+
+    /**
+     * 사용자에게 role 부여
+     * 
+     * @param email 사용자 이메일
+     * @param role 부여할 role
+     * @throws IamException IAM API 호출 실패 시
+     */
+    public void assignRole(String email, IamRole role) throws IamException {
+        assignRoles(email, List.of(role));
+    }
+
+    /**
+     * 사용자에게 여러 role 부여
+     * 
+     * @param email 사용자 이메일
+     * @param roles 부여할 role 목록
+     * @throws IamException IAM API 호출 실패 시
+     */
+    public void assignRoles(String email, List<IamRole> roles) throws IamException {
+        // 1. Email로 subject 조회
+        String subject = iamClient.getUserSubjectByEmail(email);
+        
+        // 2. 각 Role 부여
+        iamClient.assignRoles(subject, roles);
+        log.info("Roles assigned: email={}, subject={}, roles={}", email, subject, roles);
+    }
+
+    /**
+     * 사용자로부터 role 제거
+     * 
+     * @param email 사용자 이메일
+     * @param role 제거할 role
+     * @throws IamException IAM API 호출 실패 시
+     */
+    public void removeRole(String email, IamRole role) throws IamException {
+        // 1. Email로 subject 조회
+        String subject = iamClient.getUserSubjectByEmail(email);
+        
+        // 2. Role 제거
+        iamClient.removeRole(subject, role);
+        log.info("Role removed: email={}, subject={}, role={}", email, subject, role);
+    }
+
+    /**
+     * 사용자의 role 목록 조회
+     * 
+     * @param email 사용자 이메일
+     * @return 사용자가 가진 role 목록
+     * @throws IamException IAM API 호출 실패 시
+     */
+    @Transactional(readOnly = true)
+    public List<IamRole> getUserRoles(String email) throws IamException {
+        // 1. Email로 subject 조회
+        String subject = iamClient.getUserSubjectByEmail(email);
+        
+        // 2. Role 조회
+        List<IamRole> roles = iamClient.getUserRoles(subject);
+        log.info("User roles retrieved: email={}, subject={}, roles={}", email, subject, roles);
+        return roles;
+    }
+
+    /**
+     * 현재 로그인한 사용자의 role 목록 조회
+     * 
+     * @return 현재 사용자가 가진 role 목록
+     */
+    @Transactional(readOnly = true)
+    public List<IamRole> getCurrentUserRoles() {
+        return jwtUtils.getCurrentUserRoles();
+    }
+
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/application/user/UserService.java
+++ b/be/src/main/java/io/hlab/OpenConsole/application/user/UserService.java
@@ -1,7 +1,6 @@
 package io.hlab.OpenConsole.application.user;
 
 import io.hlab.OpenConsole.common.exception.ErrorCode;
-import io.hlab.OpenConsole.domain.user.IamProvider;
 import io.hlab.OpenConsole.domain.user.User;
 import io.hlab.OpenConsole.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,12 +17,19 @@ import java.util.Optional;
 public class UserService {
     private final UserRepository userRepository;
 
-    public Long createUser(String email, String name, IamProvider provider, String subject) {
+    /**
+     * 사용자 생성
+     * 
+     * @param email 이메일
+     * @param name 이름
+     * @return 생성된 사용자 ID
+     */
+    public Long createUser(String email, String name) {
         if (userRepository.existsByEmail(email)) {
             throw ErrorCode.USER_ALREADY_EXISTS.toException();
         }
 
-        User user = User.create(email, name, provider, subject);
+        User user = User.create(email, name);
         User savedUser = userRepository.save(user);
         log.info("User created: id={}, email={}", savedUser.getId(), savedUser.getEmail());
         return savedUser.getId();
@@ -42,14 +48,8 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public User getUserBySubject(IamProvider provider, String subject) {
-        return userRepository.findByProviderAndSubject(provider, subject)
-                .orElseThrow(() -> ErrorCode.USER_NOT_FOUND.toException());
-    }
-
-    @Transactional(readOnly = true)
-    public Optional<User> findUserBySubject(IamProvider provider, String subject) {
-        return userRepository.findByProviderAndSubject(provider, subject);
+    public Optional<User> findUserByEmail(String email) {
+        return userRepository.findByEmail(email);
     }
 
     @Transactional(readOnly = true)
@@ -57,9 +57,15 @@ public class UserService {
         return userRepository.existsByEmail(email);
     }
 
+    /**
+     * 사용자 생성 (엔티티 직접 저장)
+     * 
+     * @param user User 엔티티
+     * @return 저장된 User 엔티티
+     */
     public User createUser(User user) {
         User savedUser = userRepository.save(user);
-        log.info("User created: id={}, email={}, subject={}", savedUser.getId(), savedUser.getEmail(), savedUser.getSubject());
+        log.info("User created: id={}, email={}", savedUser.getId(), savedUser.getEmail());
         return savedUser;
     }
 

--- a/be/src/main/java/io/hlab/OpenConsole/common/exception/ErrorCode.java
+++ b/be/src/main/java/io/hlab/OpenConsole/common/exception/ErrorCode.java
@@ -9,6 +9,8 @@ public enum ErrorCode {
     USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다.", 404),
     USER_ALREADY_EXISTS("USER_ALREADY_EXISTS", "이미 존재하는 사용자입니다.", 409),
     INVALID_INPUT("INVALID_INPUT", "잘못된 입력입니다.", 400),
+    UNAUTHORIZED("UNAUTHORIZED", "인증이 필요합니다.", 401),
+    FORBIDDEN("FORBIDDEN", "접근 권한이 없습니다.", 403),
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.", 500);
 
     private final String code;

--- a/be/src/main/java/io/hlab/OpenConsole/common/exception/ErrorCode.java
+++ b/be/src/main/java/io/hlab/OpenConsole/common/exception/ErrorCode.java
@@ -6,8 +6,18 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+    // User 관련
     USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다.", 404),
     USER_ALREADY_EXISTS("USER_ALREADY_EXISTS", "이미 존재하는 사용자입니다.", 409),
+    
+    // IAM 관련
+    IAM_ERROR("IAM_ERROR", "IAM 처리 중 오류가 발생했습니다.", 500),
+    IAM_USER_NOT_FOUND("IAM_USER_NOT_FOUND", "IAM에서 사용자를 찾을 수 없습니다.", 404),
+    IAM_ROLE_ASSIGN_FAILED("IAM_ROLE_ASSIGN_FAILED", "Role 부여에 실패했습니다.", 500),
+    IAM_ROLE_REMOVE_FAILED("IAM_ROLE_REMOVE_FAILED", "Role 제거에 실패했습니다.", 500),
+    IAM_ROLE_QUERY_FAILED("IAM_ROLE_QUERY_FAILED", "Role 조회에 실패했습니다.", 500),
+    
+    // 공통
     INVALID_INPUT("INVALID_INPUT", "잘못된 입력입니다.", 400),
     UNAUTHORIZED("UNAUTHORIZED", "인증이 필요합니다.", 401),
     FORBIDDEN("FORBIDDEN", "접근 권한이 없습니다.", 403),

--- a/be/src/main/java/io/hlab/OpenConsole/common/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/io/hlab/OpenConsole/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package io.hlab.OpenConsole.common.exception;
 
 import io.hlab.OpenConsole.common.dto.ApiResponse;
+import io.hlab.OpenConsole.infrastructure.iam.IamException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,16 @@ public class GlobalExceptionHandler {
         log.warn("BusinessException: {} - {}", e.getErrorCode(), e.getMessage());
         ApiResponse<Object> response = ApiResponse.error(e.getErrorCode(), e.getMessage());
         return ResponseEntity.status(e.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(IamException.class)
+    public ResponseEntity<ApiResponse<Object>> handleIamException(IamException e) {
+        log.error("IAM 오류 발생: {}", e.getMessage(), e);
+        ApiResponse<Object> response = ApiResponse.error(
+                ErrorCode.IAM_ERROR.getCode(),
+                e.getMessage()
+        );
+        return ResponseEntity.status(ErrorCode.IAM_ERROR.getStatus()).body(response);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/be/src/main/java/io/hlab/OpenConsole/common/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/io/hlab/OpenConsole/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import io.hlab.OpenConsole.common.dto.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -38,6 +40,16 @@ public class GlobalExceptionHandler {
                 "입력값 검증에 실패했습니다."
         );
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler({AuthorizationDeniedException.class, AccessDeniedException.class})
+    public ResponseEntity<ApiResponse<Object>> handleAuthorizationDeniedException(Exception e) {
+        log.warn("Authorization denied: {}", e.getMessage());
+        ApiResponse<Object> response = ApiResponse.error(
+                "FORBIDDEN",
+                "접근 권한이 없습니다."
+        );
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
     }
 
     @ExceptionHandler(Exception.class)

--- a/be/src/main/java/io/hlab/OpenConsole/domain/user/IamProvider.java
+++ b/be/src/main/java/io/hlab/OpenConsole/domain/user/IamProvider.java
@@ -1,0 +1,9 @@
+package io.hlab.OpenConsole.domain.user;
+
+public enum IamProvider {
+    ZITADEL,
+    KEYCLOAK,
+    GOOGLE,
+    GITHUB,
+    LOCAL
+}

--- a/be/src/main/java/io/hlab/OpenConsole/domain/user/User.java
+++ b/be/src/main/java/io/hlab/OpenConsole/domain/user/User.java
@@ -2,6 +2,8 @@ package io.hlab.OpenConsole.domain.user;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,10 +13,19 @@ import java.time.LocalDateTime;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
+    private String subject; // IAM에서 넘겨준 고유 식별자 (sub)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private IamProvider provider;
 
     @Column(nullable = false, unique = true, length = 100)
     private String email;
@@ -39,13 +50,29 @@ public class User {
         updatedAt = LocalDateTime.now();
     }
 
-    private User(String email, String name) {
-        this.email = email;
-        this.name = name;
+    public static User create(String email, String name, IamProvider provider, String subject) {
+        return User.builder()
+                .email(email)
+                .name(name)
+                .provider(provider)
+                .subject(subject)
+                .build();
     }
 
-    public static User create(String email, String name) {
-        return new User(email, name);
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public void setProvider(IamProvider provider) {
+        this.provider = provider;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public void updateName(String name) {

--- a/be/src/main/java/io/hlab/OpenConsole/domain/user/User.java
+++ b/be/src/main/java/io/hlab/OpenConsole/domain/user/User.java
@@ -20,13 +20,6 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private String subject; // IAM에서 넘겨준 고유 식별자 (sub)
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private IamProvider provider;
-
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 
@@ -50,21 +43,19 @@ public class User {
         updatedAt = LocalDateTime.now();
     }
 
-    public static User create(String email, String name, IamProvider provider, String subject) {
+    /**
+     * 사용자 생성
+     * IAM 정보(subject, provider)는 저장하지 않음 (IAM이 SSOT)
+     * 
+     * @param email 이메일
+     * @param name 이름
+     * @return User 엔티티
+     */
+    public static User create(String email, String name) {
         return User.builder()
                 .email(email)
                 .name(name)
-                .provider(provider)
-                .subject(subject)
                 .build();
-    }
-
-    public void setSubject(String subject) {
-        this.subject = subject;
-    }
-
-    public void setProvider(IamProvider provider) {
-        this.provider = provider;
     }
 
     public void setEmail(String email) {

--- a/be/src/main/java/io/hlab/OpenConsole/domain/user/UserRepository.java
+++ b/be/src/main/java/io/hlab/OpenConsole/domain/user/UserRepository.java
@@ -9,6 +9,8 @@ public interface UserRepository {
 
     Optional<User> findByEmail(String email);
 
+    Optional<User> findByProviderAndSubject(IamProvider provider, String subject);
+
     boolean existsByEmail(String email);
 
     void deleteById(Long id);

--- a/be/src/main/java/io/hlab/OpenConsole/domain/user/UserRepository.java
+++ b/be/src/main/java/io/hlab/OpenConsole/domain/user/UserRepository.java
@@ -9,8 +9,6 @@ public interface UserRepository {
 
     Optional<User> findByEmail(String email);
 
-    Optional<User> findByProviderAndSubject(IamProvider provider, String subject);
-
     boolean existsByEmail(String email);
 
     void deleteById(Long id);

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/config/OpenApiConfig.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/config/OpenApiConfig.java
@@ -1,0 +1,54 @@
+package io.hlab.OpenConsole.infrastructure.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * SpringDoc OpenAPI 설정
+ * Swagger UI에서 JWT Bearer 토큰을 사용할 수 있도록 설정
+ * 
+ * 참고: OAuth2 로그인은 Swagger UI에서 지원하지 않습니다.
+ * Zitadel에서 직접 로그인하여 JWT 토큰을 발급받은 후,
+ * Swagger UI의 "Authorize" 버튼을 클릭하여 Bearer JWT 토큰을 입력하세요.
+ */
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("OpenConsole API")
+                        .version("1.0.0")
+                        .description("""
+                                VPS 서비스 백엔드 API 문서
+                                
+                                ## 인증 방법
+                                1. Zitadel에서 로그인하여 JWT 토큰을 발급받으세요.
+                                   - 프론트엔드에서 로그인하거나
+                                   - 브라우저에서 직접 로그인
+                                2. Swagger UI 우측 상단의 "Authorize" 버튼을 클릭하세요.
+                                3. "bearer-jwt" 섹션에 JWT 토큰을 입력하세요.
+                                   (예: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...)
+                                4. "Authorize" 버튼을 클릭하여 저장하세요.
+                                
+                                ## JWT 토큰 발급 방법
+                                - 브라우저 개발자 도구 → Application/Storage 탭에서 확인
+                                - 또는 Network 탭에서 API 요청의 Authorization 헤더 확인
+                                - 자세한 내용은 docs/ZITADEL_JWT_TOKEN_GUIDE.md 참고
+                                """))
+                .components(new Components()
+                        .addSecuritySchemes("bearer-jwt", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("Zitadel에서 발급받은 JWT 토큰을 입력하세요. 'Bearer ' 접두사는 자동으로 추가됩니다.")))
+                .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"));
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamClient.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamClient.java
@@ -6,7 +6,41 @@ import java.util.List;
  * IAM 클라이언트 인터페이스
  * IAM 시스템에 role을 부여하거나 관리하는 기능을 추상화
  * 
- * 구현체는 각 IAM 솔루션별로 제공됨 (예: ZitadelClient, KeycloakClient)
+ * <h3>구현체</h3>
+ * <ul>
+ *   <li>{@link io.hlab.OpenConsole.infrastructure.iam.zitadel.ZitadelClient}: Zitadel 구현체</li>
+ * </ul>
+ * 
+ * <h3>사용 예시</h3>
+ * <pre>{@code
+ * // Role 부여
+ * iamClient.assignRole(userId, IamRole.ADMIN);
+ * 
+ * // 여러 Role 부여
+ * iamClient.assignRoles(userId, List.of(IamRole.ADMIN, IamRole.USER_A));
+ * 
+ * // Role 제거
+ * iamClient.removeRole(userId, IamRole.USER_A);
+ * 
+ * // Role 조회
+ * List<IamRole> roles = iamClient.getUserRoles(userId);
+ * 
+ * // Email → Subject 변환
+ * String subject = iamClient.getUserSubjectByEmail(email);
+ * 
+ * // Subject → Email 변환
+ * String email = iamClient.getUserEmailBySubject(subject);
+ * }</pre>
+ * 
+ * <h3>향후 확장 방안</h3>
+ * <ul>
+ *   <li>Organization 기능 추가 시: {@code IamOrganizationClient} 인터페이스로 분리 예정</li>
+ *   <li>블랙리스트 기능: {@code IamTokenBlacklistClient} 인터페이스로 분리 예정</li>
+ * </ul>
+ * 
+ * @see io.hlab.OpenConsole.infrastructure.iam.zitadel.ZitadelClient
+ * @see io.hlab.OpenConsole.infrastructure.iam.IamException
+ * @see io.hlab.OpenConsole.infrastructure.iam.IamRole
  */
 public interface IamClient {
 

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamClient.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamClient.java
@@ -1,0 +1,67 @@
+package io.hlab.OpenConsole.infrastructure.iam;
+
+import java.util.List;
+
+/**
+ * IAM 클라이언트 인터페이스
+ * IAM 시스템에 role을 부여하거나 관리하는 기능을 추상화
+ * 
+ * 구현체는 각 IAM 솔루션별로 제공됨 (예: ZitadelClient, KeycloakClient)
+ */
+public interface IamClient {
+
+    /**
+     * 사용자에게 role을 부여
+     * 
+     * @param userId IAM의 사용자 ID (subject)
+     * @param role 부여할 role
+     * @throws IamException IAM API 호출 실패 시
+     */
+    void assignRole(String userId, IamRole role) throws IamException;
+
+    /**
+     * 사용자에게 여러 role을 부여
+     * 
+     * @param userId IAM의 사용자 ID (subject)
+     * @param roles 부여할 role 목록
+     * @throws IamException IAM API 호출 실패 시
+     */
+    void assignRoles(String userId, List<IamRole> roles) throws IamException;
+
+    /**
+     * 사용자로부터 role을 제거
+     * 
+     * @param userId IAM의 사용자 ID (subject)
+     * @param role 제거할 role
+     * @throws IamException IAM API 호출 실패 시
+     */
+    void removeRole(String userId, IamRole role) throws IamException;
+
+    /**
+     * 사용자의 모든 role 목록 조회
+     * 
+     * @param userId IAM의 사용자 ID (subject)
+     * @return 사용자가 가진 role 목록
+     * @throws IamException IAM API 호출 실패 시
+     */
+    List<IamRole> getUserRoles(String userId) throws IamException;
+
+    /**
+     * Email로 사용자의 subject 조회
+     * 
+     * @param email 사용자 이메일
+     * @return IAM의 사용자 ID (subject)
+     * @throws IamException IAM API 호출 실패 시
+     */
+    String getUserSubjectByEmail(String email) throws IamException;
+
+    /**
+     * Subject로 사용자의 email 조회
+     * 
+     * @param subject IAM의 사용자 ID (subject)
+     * @return 사용자 이메일
+     * @throws IamException IAM API 호출 실패 시
+     */
+    String getUserEmailBySubject(String subject) throws IamException;
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamException.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamException.java
@@ -10,8 +10,10 @@ package io.hlab.OpenConsole.infrastructure.iam;
  * </p>
  * <ul>
  *   <li><b>Infrastructure 레이어</b>: IamException을 catch하여 로깅 없이 그대로 전파합니다.
- *       로깅은 상위 레이어(Controller)에서 수행하여 중복 로깅을 방지합니다.</li>
- *   <li><b>API 레이어</b>: IamException을 catch하여 로깅하고 사용자에게 적절한 에러 응답을 반환합니다.</li>
+ *       로깅은 전역 예외 핸들러에서 수행하여 중복 로깅을 방지합니다.</li>
+ *   <li><b>Application 레이어</b>: IamException을 그대로 전파합니다.</li>
+ *   <li><b>API 레이어</b>: IamException을 처리하지 않고 그대로 전파합니다.
+ *       전역 예외 핸들러({@link io.hlab.OpenConsole.common.exception.GlobalExceptionHandler})에서 처리됩니다.</li>
  *   <li><b>예상치 못한 예외</b>: Infrastructure 레이어에서 Exception을 catch하여 로깅하고
  *       IamException으로 래핑하여 전파합니다.</li>
  * </ul>
@@ -30,12 +32,8 @@ package io.hlab.OpenConsole.infrastructure.iam;
  * }
  * 
  * // API 레이어 (RoleController)
- * try {
- *     roleService.assignRole(email, role);
- * } catch (IamException e) {
- *     log.error("Role 부여 실패", e);  // 여기서 로깅
- *     return ApiResponse.error("ROLE_ASSIGN_FAILED", e.getMessage());
- * }
+ * // try-catch 불필요, GlobalExceptionHandler에서 처리
+ * roleService.assignRole(email, role);
  * }</pre>
  * </p>
  */

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamException.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamException.java
@@ -1,0 +1,52 @@
+package io.hlab.OpenConsole.infrastructure.iam;
+
+/**
+ * IAM 관련 예외
+ * IAM API 호출 실패, 토큰 검증 실패 등을 표현
+ * 
+ * <h3>예외 처리 패턴</h3>
+ * <p>
+ * 이 예외는 예상 가능한 비즈니스 예외로, 다음과 같은 처리 패턴을 따릅니다:
+ * </p>
+ * <ul>
+ *   <li><b>Infrastructure 레이어</b>: IamException을 catch하여 로깅 없이 그대로 전파합니다.
+ *       로깅은 상위 레이어(Controller)에서 수행하여 중복 로깅을 방지합니다.</li>
+ *   <li><b>API 레이어</b>: IamException을 catch하여 로깅하고 사용자에게 적절한 에러 응답을 반환합니다.</li>
+ *   <li><b>예상치 못한 예외</b>: Infrastructure 레이어에서 Exception을 catch하여 로깅하고
+ *       IamException으로 래핑하여 전파합니다.</li>
+ * </ul>
+ * 
+ * <p>
+ * 예시:
+ * <pre>{@code
+ * // Infrastructure 레이어 (ZitadelClient)
+ * try {
+ *     userExecutor.findUserByEmail(email);
+ * } catch (IamException e) {
+ *     throw e;  // 로깅 없이 전파
+ * } catch (Exception e) {
+ *     log.error("예상치 못한 예외", e);  // 로깅 후 래핑
+ *     throw new IamException("처리 실패", e);
+ * }
+ * 
+ * // API 레이어 (RoleController)
+ * try {
+ *     roleService.assignRole(email, role);
+ * } catch (IamException e) {
+ *     log.error("Role 부여 실패", e);  // 여기서 로깅
+ *     return ApiResponse.error("ROLE_ASSIGN_FAILED", e.getMessage());
+ * }
+ * }</pre>
+ * </p>
+ */
+public class IamException extends RuntimeException {
+
+    public IamException(String message) {
+        super(message);
+    }
+
+    public IamException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamRole.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamRole.java
@@ -1,0 +1,69 @@
+package io.hlab.OpenConsole.infrastructure.iam;
+
+/**
+ * IAM Role Enum
+ * IAM에서 사용하는 Role을 표현
+ */
+public enum IamRole {
+    ADMIN("admin"),
+    USER("user"),  // Zitadel에서 사용하는 기본 user role
+    USER_A("userA"),
+    USER_B("userB"),
+    USER_C("userC");
+
+    private final String value;
+
+    IamRole(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Role 문자열 값을 반환 (IAM API 호출 시 사용)
+     * 
+     * @return role 문자열 값
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * 문자열로부터 IamRole을 찾음
+     * 
+     * @param roleString role 문자열
+     * @return IamRole 또는 null (없는 경우)
+     */
+    public static IamRole fromString(String roleString) {
+        if (roleString == null || roleString.isBlank()) {
+            return null;
+        }
+        
+        for (IamRole role : values()) {
+            if (role.value.equalsIgnoreCase(roleString)) {
+                return role;
+            }
+        }
+        
+        return null;
+    }
+
+    /**
+     * 문자열로부터 IamRole을 찾음 (of 메서드와 동일, 호환성 유지)
+     * 
+     * @param roleString role 문자열
+     * @return IamRole
+     * @throws IllegalArgumentException role이 존재하지 않는 경우
+     */
+    public static IamRole of(String roleString) {
+        IamRole role = fromString(roleString);
+        if (role == null) {
+            throw new IllegalArgumentException("Unknown role: " + roleString);
+        }
+        return role;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamTokenDecoder.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamTokenDecoder.java
@@ -1,0 +1,39 @@
+package io.hlab.OpenConsole.infrastructure.iam;
+
+import java.util.Map;
+
+/**
+ * IAM 토큰 디코더 인터페이스
+ * JWT 토큰을 디코딩하여 사용자 정보와 role을 추출
+ * 
+ * 구현체는 각 IAM 솔루션별로 제공됨 (예: ZitadelTokenDecoder, KeycloakTokenDecoder)
+ */
+public interface IamTokenDecoder {
+
+    /**
+     * JWT 토큰을 디코딩하여 사용자 정보 추출
+     * 
+     * @param token JWT 토큰 문자열
+     * @return 사용자 정보 (subject, email, name, roles 포함)
+     * @throws IamException 토큰 검증 실패 또는 디코딩 실패 시
+     */
+    IamUserInfo decode(String token) throws IamException;
+
+    /**
+     * JWT claims에서 사용자 정보 추출
+     * SecurityContext에서 가져온 JWT claims를 IamUserInfo로 변환
+     * 
+     * @param claims JWT claims (Map<String, Object>)
+     * @return 사용자 정보 (subject, email, name, roles 포함)
+     */
+    IamUserInfo fromClaims(Map<String, Object> claims);
+
+    /**
+     * 토큰이 유효한지 검증
+     * 
+     * @param token JWT 토큰 문자열
+     * @return 유효하면 true, 그렇지 않으면 false
+     */
+    boolean isValid(String token);
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamUserInfo.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/IamUserInfo.java
@@ -1,0 +1,37 @@
+package io.hlab.OpenConsole.infrastructure.iam;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+/**
+ * IAM에서 추출한 사용자 정보
+ * 토큰 디코딩 결과를 담는 값 객체
+ */
+@Getter
+@RequiredArgsConstructor
+public class IamUserInfo {
+    private final String subject;      // IAM의 고유 사용자 ID (sub)
+    private final String email;
+    private final String name;
+    private final List<IamRole> roles; // 사용자가 가진 역할 목록
+
+    public static IamUserInfo of(String subject, String email, String name, List<IamRole> roles) {
+        return new IamUserInfo(subject, email, name, roles);
+    }
+
+    public boolean hasRole(IamRole role) {
+        return roles.contains(role);
+    }
+
+    public boolean hasAnyRole(IamRole... roles) {
+        for (IamRole role : roles) {
+            if (this.roles.contains(role)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/ZitadelClient.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/ZitadelClient.java
@@ -1,0 +1,257 @@
+package io.hlab.OpenConsole.infrastructure.iam.zitadel;
+
+import io.hlab.OpenConsole.infrastructure.iam.IamClient;
+import io.hlab.OpenConsole.infrastructure.iam.IamException;
+import io.hlab.OpenConsole.infrastructure.iam.IamRole;
+import io.hlab.OpenConsole.infrastructure.iam.zitadel.client.ZitadelAuthExecutor;
+import io.hlab.OpenConsole.infrastructure.iam.zitadel.client.ZitadelUserExecutor;
+import io.hlab.OpenConsole.infrastructure.iam.zitadel.dto.ZitadelAuthorizationDto;
+import io.hlab.OpenConsole.infrastructure.iam.zitadel.dto.ZitadelUserDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Zitadel Management API 클라이언트 구현체 (Facade)
+ * IamClient 인터페이스를 구현하며, 내부적으로 ZitadelAuthExecutor 등을 사용
+ * 서비스 로직만 담당하고, 실제 API 호출은 Executor에 위임
+ * 
+ * <h3>예외 처리 패턴</h3>
+ * <ul>
+ *   <li><b>IamException</b>: 예상 가능한 비즈니스 예외이므로 로깅 없이 그대로 전파합니다.
+ *       로깅은 상위 레이어(Controller)에서 수행합니다.</li>
+ *   <li><b>Exception</b>: 예상치 못한 예외는 로깅 후 IamException으로 래핑하여 전파합니다.</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ZitadelClient implements IamClient {
+
+    @Value("${zitadel.domain}")
+    private String zitadelDomain;
+
+    @Value("${zitadel.org-id}")
+    private String orgId;
+
+    @Value("${zitadel.api-token}")
+    private String apiToken;
+
+    private final ZitadelAuthExecutor authExecutor;
+    private final ZitadelUserExecutor userExecutor;
+
+    @Override
+    public void assignRole(String userId, IamRole role) throws IamException {
+        assignRoles(userId, List.of(role));
+    }
+
+    @Override
+    public void assignRoles(String userId, List<IamRole> roles) throws IamException {
+        log.info("Zitadel에 role 부여 요청: userId={}, roles={}", userId, roles);
+
+        try {
+            List<String> roleKeys = roles.stream()
+                    .map(IamRole::getValue)
+                    .toList();
+
+            try {
+                // 먼저 CreateAuthorization 시도 (grant가 없는 경우)
+                authExecutor.createAuthorization(userId, roleKeys);
+                log.info("Zitadel role 부여 완료 (새 grant 생성): userId={}, roles={}", userId, roles);
+
+            } catch (IamException e) {
+                // IamException의 원인을 확인하여 409 Conflict인지 체크
+                if (e.getCause() instanceof WebClientResponseException cause) {
+                    if (cause.getStatusCode().value() == 409) {
+                        // grant가 이미 존재하면 기존 role과 병합하여 UpdateAuthorization 사용
+                        log.info("Grant가 이미 존재하여 기존 role과 병합 후 업데이트 시도: userId={}, roles={}", userId, roles);
+                        
+                        // 1. 현재 grant ID 조회
+                        String grantId = findAuthorizationId(userId);
+                        
+                        // 2. 현재 roleKeys 조회
+                        List<String> currentRoleKeys = getCurrentRoleKeys(userId);
+                        
+                        // 3. 기존 roleKeys와 요청한 roleKeys 병합 (중복 제거)
+                        List<String> mergedRoleKeys = new ArrayList<>(currentRoleKeys);
+                        for (String roleKey : roleKeys) {
+                            if (!mergedRoleKeys.contains(roleKey)) {
+                                mergedRoleKeys.add(roleKey);
+                            }
+                        }
+                        
+                        // 4. UpdateAuthorization으로 업데이트
+                        authExecutor.updateAuthorization(grantId, mergedRoleKeys);
+                        
+                        log.info("Zitadel role 부여 완료 (기존 grant 업데이트): userId={}, grantId={}, 기존 roles={}, 추가 roles={}, 최종 roles={}", 
+                                userId, grantId, currentRoleKeys, roleKeys, mergedRoleKeys);
+                    } else {
+                        throw e;
+                    }
+                } else {
+                    throw e;
+                }
+            }
+
+        } catch (WebClientResponseException e) {
+            log.error("Zitadel role 부여 실패: userId={}, roles={}, status={}, body={}",
+                    userId, roles, e.getStatusCode(), e.getResponseBodyAsString());
+            throw new IamException("Zitadel role 부여 실패: " + e.getMessage(), e);
+        } catch (Exception e) {
+            log.error("Zitadel role 부여 중 예외 발생: userId={}, roles={}", userId, roles, e);
+            throw new IamException("Zitadel role 부여 중 예외 발생: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void removeRole(String userId, IamRole role) throws IamException {
+        log.info("Zitadel에서 role 제거 요청: userId={}, role={}", userId, role);
+
+        try {
+            // 1. 현재 grant ID 조회
+            String grantId = findAuthorizationId(userId);
+            
+            // 2. 현재 roleKeys 조회
+            List<String> currentRoleKeys = getCurrentRoleKeys(userId);
+            
+            // 3. 제거할 roleKey를 현재 roleKeys에서 제거
+            List<String> updatedRoleKeys = currentRoleKeys.stream()
+                    .filter(roleKey -> !roleKey.equals(role.getValue()))
+                    .toList();
+
+            // 4. UpdateAuthorization으로 업데이트
+            authExecutor.updateAuthorization(grantId, updatedRoleKeys);
+
+            log.info("Zitadel role 제거 완료: userId={}, grantId={}, removedRole={}, remainingRoles={}", 
+                    userId, grantId, role, updatedRoleKeys);
+
+        } catch (Exception e) {
+            log.error("Zitadel role 제거 중 예외 발생: userId={}, role={}", userId, role, e);
+            throw new IamException("Zitadel role 제거 중 예외 발생: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<IamRole> getUserRoles(String userId) throws IamException {
+        log.info("Zitadel에서 사용자 role 조회: userId={}", userId);
+
+        try {
+            ZitadelAuthorizationDto.ListResponse response = authExecutor.listAuthorizations(userId);
+            
+            // 응답에서 roleKeys 추출하여 IamRole 리스트로 변환
+            List<IamRole> roles = new ArrayList<>();
+            if (response != null && response.authorizations() != null && !response.authorizations().isEmpty()) {
+                ZitadelAuthorizationDto.ListResponse.Authorization authorization = response.authorizations().get(0);
+                if (authorization.roleKeys() != null) {
+                    for (String roleKey : authorization.roleKeys()) {
+                        IamRole iamRole = IamRole.fromString(roleKey);
+                        if (iamRole != null && !roles.contains(iamRole)) {
+                            roles.add(iamRole);
+                        }
+                    }
+                }
+            }
+            
+            log.info("Zitadel role 조회 완료: userId={}, roles={}", userId, roles);
+            return roles;
+
+        } catch (Exception e) {
+            log.error("Zitadel role 조회 중 예외 발생: userId={}", userId, e);
+            throw new IamException("Zitadel role 조회 중 예외 발생: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String getUserSubjectByEmail(String email) throws IamException {
+        log.info("Zitadel에서 email로 사용자 조회: email={}", email);
+
+        try {
+            ZitadelUserDto.ListUsersResponse.User user = userExecutor.findUserByEmail(email);
+            
+            // id 또는 userId 필드에서 subject 추출
+            String subject = user.id() != null ? user.id() : user.userId();
+            
+            if (subject != null && !subject.isBlank()) {
+                log.info("Zitadel 사용자 조회 성공: email={}, subject={}", email, subject);
+                return subject;
+            }
+            
+            throw new IamException("사용자 ID를 찾을 수 없습니다: email=" + email);
+        } catch (IamException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Zitadel 사용자 조회 중 예외 발생: email={}", email, e);
+            throw new IamException("Zitadel 사용자 조회 중 예외 발생: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String getUserEmailBySubject(String subject) throws IamException {
+        log.info("Zitadel에서 subject로 사용자 조회: subject={}", subject);
+
+        try {
+            ZitadelUserDto.GetUserByIDResponse response = userExecutor.getUserByID(subject);
+            
+            if (response != null && response.user() != null) {
+                ZitadelUserDto.ListUsersResponse.User user = response.user();
+                
+                // Human 타입 사용자의 email 추출
+                if (user.human() != null && user.human().email() != null) {
+                    String email = user.human().email().email();
+                    if (email != null && !email.isBlank()) {
+                        log.info("Zitadel 사용자 조회 성공: subject={}, email={}", subject, email);
+                        return email;
+                    }
+                }
+            }
+
+            throw new IamException("사용자 email을 찾을 수 없습니다: subject=" + subject);
+        } catch (IamException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Zitadel 사용자 조회 중 예외 발생: subject={}", subject, e);
+            throw new IamException("Zitadel 사용자 조회 중 예외 발생: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Authorization ID 조회 (헬퍼 메소드)
+     */
+    private String findAuthorizationId(String userId) throws IamException {
+        ZitadelAuthorizationDto.ListResponse response = authExecutor.listAuthorizations(userId);
+        
+        if (response != null && response.authorizations() != null && !response.authorizations().isEmpty()) {
+            ZitadelAuthorizationDto.ListResponse.Authorization firstGrant = response.authorizations().get(0);
+            String grantId = firstGrant.id();
+            if (grantId != null && !grantId.isBlank()) {
+                log.debug("Authorization ID 조회 완료: userId={}, grantId={}", userId, grantId);
+                return grantId;
+            }
+        }
+
+        throw new IamException("Grant ID를 찾을 수 없습니다: userId=" + userId);
+    }
+
+    /**
+     * 현재 사용자의 roleKeys 조회 (헬퍼 메소드)
+     */
+    private List<String> getCurrentRoleKeys(String userId) throws IamException {
+        ZitadelAuthorizationDto.ListResponse response = authExecutor.listAuthorizations(userId);
+        List<String> currentRoleKeys = new ArrayList<>();
+        
+        if (response != null && response.authorizations() != null && !response.authorizations().isEmpty()) {
+            ZitadelAuthorizationDto.ListResponse.Authorization authorization = response.authorizations().get(0);
+            if (authorization.roleKeys() != null) {
+                currentRoleKeys = new ArrayList<>(authorization.roleKeys());
+            }
+        }
+        
+        return currentRoleKeys;
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/ZitadelClient.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/ZitadelClient.java
@@ -15,6 +15,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Zitadel Management API 클라이언트 구현체 (Facade)
@@ -23,9 +24,12 @@ import java.util.List;
  * 
  * <h3>예외 처리 패턴</h3>
  * <ul>
- *   <li><b>IamException</b>: 예상 가능한 비즈니스 예외이므로 로깅 없이 그대로 전파합니다.
- *       로깅은 상위 레이어(Controller)에서 수행합니다.</li>
- *   <li><b>Exception</b>: 예상치 못한 예외는 로깅 후 IamException으로 래핑하여 전파합니다.</li>
+ *   <li><b>IamException</b>: Executor에서 이미 IamException으로 변환되어 전파되므로,
+ *       비즈니스 로직(예: 409 Conflict 처리)이 필요한 경우에만 catch하고 처리합니다.
+ *       그 외에는 그대로 전파합니다. 로깅은 GlobalExceptionHandler에서 수행합니다.</li>
+ *   <li><b>Executor의 예외 처리</b>: ZitadelAuthExecutor와 ZitadelUserExecutor에서
+ *       WebClientResponseException을 catch하고 IamException으로 래핑하므로,
+ *       이 클래스에서는 추가적인 예외 래핑이 불필요합니다.</li>
  * </ul>
  */
 @Slf4j
@@ -54,57 +58,50 @@ public class ZitadelClient implements IamClient {
     public void assignRoles(String userId, List<IamRole> roles) throws IamException {
         log.info("Zitadel에 role 부여 요청: userId={}, roles={}", userId, roles);
 
+        List<String> roleKeys = roles.stream()
+                .map(IamRole::getValue)
+                .toList();
+
         try {
-            List<String> roleKeys = roles.stream()
-                    .map(IamRole::getValue)
-                    .toList();
+            // 먼저 CreateAuthorization 시도 (grant가 없는 경우)
+            authExecutor.createAuthorization(userId, roleKeys);
+            log.info("Zitadel role 부여 완료 (새 grant 생성): userId={}, roles={}", userId, roles);
 
-            try {
-                // 먼저 CreateAuthorization 시도 (grant가 없는 경우)
-                authExecutor.createAuthorization(userId, roleKeys);
-                log.info("Zitadel role 부여 완료 (새 grant 생성): userId={}, roles={}", userId, roles);
-
-            } catch (IamException e) {
-                // IamException의 원인을 확인하여 409 Conflict인지 체크
-                if (e.getCause() instanceof WebClientResponseException cause) {
-                    if (cause.getStatusCode().value() == 409) {
-                        // grant가 이미 존재하면 기존 role과 병합하여 UpdateAuthorization 사용
-                        log.info("Grant가 이미 존재하여 기존 role과 병합 후 업데이트 시도: userId={}, roles={}", userId, roles);
-                        
-                        // 1. 현재 grant ID 조회
-                        String grantId = findAuthorizationId(userId);
-                        
-                        // 2. 현재 roleKeys 조회
-                        List<String> currentRoleKeys = getCurrentRoleKeys(userId);
-                        
-                        // 3. 기존 roleKeys와 요청한 roleKeys 병합 (중복 제거)
-                        List<String> mergedRoleKeys = new ArrayList<>(currentRoleKeys);
-                        for (String roleKey : roleKeys) {
-                            if (!mergedRoleKeys.contains(roleKey)) {
-                                mergedRoleKeys.add(roleKey);
-                            }
+        } catch (IamException e) {
+            // IamException의 원인을 확인하여 409 Conflict인지 체크
+            if (e.getCause() instanceof WebClientResponseException cause) {
+                if (cause.getStatusCode().value() == 409) {
+                    // grant가 이미 존재하면 기존 role과 병합하여 UpdateAuthorization 사용
+                    log.info("Grant가 이미 존재하여 기존 role과 병합 후 업데이트 시도: userId={}, roles={}", userId, roles);
+                    
+                    // 1. 현재 grant ID 조회
+                    String grantId = findAuthorizationId(userId)
+                            .orElseThrow(() -> new IamException("Grant ID를 찾을 수 없습니다: userId=" + userId));
+                    
+                    // 2. 현재 roleKeys 조회
+                    List<String> currentRoleKeys = getCurrentRoleKeys(userId);
+                    
+                    // 3. 기존 roleKeys와 요청한 roleKeys 병합 (중복 제거)
+                    List<String> mergedRoleKeys = new ArrayList<>(currentRoleKeys);
+                    for (String roleKey : roleKeys) {
+                        if (!mergedRoleKeys.contains(roleKey)) {
+                            mergedRoleKeys.add(roleKey);
                         }
-                        
-                        // 4. UpdateAuthorization으로 업데이트
-                        authExecutor.updateAuthorization(grantId, mergedRoleKeys);
-                        
-                        log.info("Zitadel role 부여 완료 (기존 grant 업데이트): userId={}, grantId={}, 기존 roles={}, 추가 roles={}, 최종 roles={}", 
-                                userId, grantId, currentRoleKeys, roleKeys, mergedRoleKeys);
-                    } else {
-                        throw e;
                     }
+                    
+                    // 4. UpdateAuthorization으로 업데이트
+                    authExecutor.updateAuthorization(grantId, mergedRoleKeys);
+                    
+                    log.info("Zitadel role 부여 완료 (기존 grant 업데이트): userId={}, grantId={}, 기존 roles={}, 추가 roles={}, 최종 roles={}", 
+                            userId, grantId, currentRoleKeys, roleKeys, mergedRoleKeys);
                 } else {
+                    // 409가 아닌 다른 IamException은 그대로 전파
                     throw e;
                 }
+            } else {
+                // WebClientResponseException이 아닌 경우 그대로 전파
+                throw e;
             }
-
-        } catch (WebClientResponseException e) {
-            log.error("Zitadel role 부여 실패: userId={}, roles={}, status={}, body={}",
-                    userId, roles, e.getStatusCode(), e.getResponseBodyAsString());
-            throw new IamException("Zitadel role 부여 실패: " + e.getMessage(), e);
-        } catch (Exception e) {
-            log.error("Zitadel role 부여 중 예외 발생: userId={}, roles={}", userId, roles, e);
-            throw new IamException("Zitadel role 부여 중 예외 발생: " + e.getMessage(), e);
         }
     }
 
@@ -112,117 +109,93 @@ public class ZitadelClient implements IamClient {
     public void removeRole(String userId, IamRole role) throws IamException {
         log.info("Zitadel에서 role 제거 요청: userId={}, role={}", userId, role);
 
-        try {
-            // 1. 현재 grant ID 조회
-            String grantId = findAuthorizationId(userId);
-            
-            // 2. 현재 roleKeys 조회
-            List<String> currentRoleKeys = getCurrentRoleKeys(userId);
-            
-            // 3. 제거할 roleKey를 현재 roleKeys에서 제거
-            List<String> updatedRoleKeys = currentRoleKeys.stream()
-                    .filter(roleKey -> !roleKey.equals(role.getValue()))
-                    .toList();
+        // 1. 현재 grant ID 조회
+        String grantId = findAuthorizationId(userId)
+                .orElseThrow(() -> new IamException("Grant ID를 찾을 수 없습니다: userId=" + userId));
+        
+        // 2. 현재 roleKeys 조회
+        List<String> currentRoleKeys = getCurrentRoleKeys(userId);
+        
+        // 3. 제거할 roleKey를 현재 roleKeys에서 제거
+        List<String> updatedRoleKeys = currentRoleKeys.stream()
+                .filter(roleKey -> !roleKey.equals(role.getValue()))
+                .toList();
 
-            // 4. UpdateAuthorization으로 업데이트
-            authExecutor.updateAuthorization(grantId, updatedRoleKeys);
+        // 4. UpdateAuthorization으로 업데이트
+        authExecutor.updateAuthorization(grantId, updatedRoleKeys);
 
-            log.info("Zitadel role 제거 완료: userId={}, grantId={}, removedRole={}, remainingRoles={}", 
-                    userId, grantId, role, updatedRoleKeys);
-
-        } catch (Exception e) {
-            log.error("Zitadel role 제거 중 예외 발생: userId={}, role={}", userId, role, e);
-            throw new IamException("Zitadel role 제거 중 예외 발생: " + e.getMessage(), e);
-        }
+        log.info("Zitadel role 제거 완료: userId={}, grantId={}, removedRole={}, remainingRoles={}", 
+                userId, grantId, role, updatedRoleKeys);
     }
 
     @Override
     public List<IamRole> getUserRoles(String userId) throws IamException {
         log.info("Zitadel에서 사용자 role 조회: userId={}", userId);
 
-        try {
-            ZitadelAuthorizationDto.ListResponse response = authExecutor.listAuthorizations(userId);
-            
-            // 응답에서 roleKeys 추출하여 IamRole 리스트로 변환
-            List<IamRole> roles = new ArrayList<>();
-            if (response != null && response.authorizations() != null && !response.authorizations().isEmpty()) {
-                ZitadelAuthorizationDto.ListResponse.Authorization authorization = response.authorizations().get(0);
-                if (authorization.roleKeys() != null) {
-                    for (String roleKey : authorization.roleKeys()) {
-                        IamRole iamRole = IamRole.fromString(roleKey);
-                        if (iamRole != null && !roles.contains(iamRole)) {
-                            roles.add(iamRole);
-                        }
+        ZitadelAuthorizationDto.ListResponse response = authExecutor.listAuthorizations(userId);
+        
+        // 응답에서 roleKeys 추출하여 IamRole 리스트로 변환
+        List<IamRole> roles = new ArrayList<>();
+        if (response != null && response.authorizations() != null && !response.authorizations().isEmpty()) {
+            ZitadelAuthorizationDto.ListResponse.Authorization authorization = response.authorizations().get(0);
+            if (authorization.roleKeys() != null) {
+                for (String roleKey : authorization.roleKeys()) {
+                    IamRole iamRole = IamRole.fromString(roleKey);
+                    if (iamRole != null && !roles.contains(iamRole)) {
+                        roles.add(iamRole);
                     }
                 }
             }
-            
-            log.info("Zitadel role 조회 완료: userId={}, roles={}", userId, roles);
-            return roles;
-
-        } catch (Exception e) {
-            log.error("Zitadel role 조회 중 예외 발생: userId={}", userId, e);
-            throw new IamException("Zitadel role 조회 중 예외 발생: " + e.getMessage(), e);
         }
+        
+        log.info("Zitadel role 조회 완료: userId={}, roles={}", userId, roles);
+        return roles;
     }
 
     @Override
     public String getUserSubjectByEmail(String email) throws IamException {
         log.info("Zitadel에서 email로 사용자 조회: email={}", email);
 
-        try {
-            ZitadelUserDto.ListUsersResponse.User user = userExecutor.findUserByEmail(email);
-            
-            // id 또는 userId 필드에서 subject 추출
-            String subject = user.id() != null ? user.id() : user.userId();
-            
-            if (subject != null && !subject.isBlank()) {
-                log.info("Zitadel 사용자 조회 성공: email={}, subject={}", email, subject);
-                return subject;
-            }
-            
-            throw new IamException("사용자 ID를 찾을 수 없습니다: email=" + email);
-        } catch (IamException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("Zitadel 사용자 조회 중 예외 발생: email={}", email, e);
-            throw new IamException("Zitadel 사용자 조회 중 예외 발생: " + e.getMessage(), e);
+        ZitadelUserDto.ListUsersResponse.User user = userExecutor.findUserByEmail(email);
+        
+        // id 또는 userId 필드에서 subject 추출
+        String subject = user.id() != null ? user.id() : user.userId();
+        
+        if (subject != null && !subject.isBlank()) {
+            log.info("Zitadel 사용자 조회 성공: email={}, subject={}", email, subject);
+            return subject;
         }
+        
+        throw new IamException("사용자 ID를 찾을 수 없습니다: email=" + email);
     }
 
     @Override
     public String getUserEmailBySubject(String subject) throws IamException {
         log.info("Zitadel에서 subject로 사용자 조회: subject={}", subject);
 
-        try {
-            ZitadelUserDto.GetUserByIDResponse response = userExecutor.getUserByID(subject);
+        ZitadelUserDto.GetUserByIDResponse response = userExecutor.getUserByID(subject);
+        
+        if (response != null && response.user() != null) {
+            ZitadelUserDto.ListUsersResponse.User user = response.user();
             
-            if (response != null && response.user() != null) {
-                ZitadelUserDto.ListUsersResponse.User user = response.user();
-                
-                // Human 타입 사용자의 email 추출
-                if (user.human() != null && user.human().email() != null) {
-                    String email = user.human().email().email();
-                    if (email != null && !email.isBlank()) {
-                        log.info("Zitadel 사용자 조회 성공: subject={}, email={}", subject, email);
-                        return email;
-                    }
+            // Human 타입 사용자의 email 추출
+            if (user.human() != null && user.human().email() != null) {
+                String email = user.human().email().email();
+                if (email != null && !email.isBlank()) {
+                    log.info("Zitadel 사용자 조회 성공: subject={}, email={}", subject, email);
+                    return email;
                 }
             }
-
-            throw new IamException("사용자 email을 찾을 수 없습니다: subject=" + subject);
-        } catch (IamException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("Zitadel 사용자 조회 중 예외 발생: subject={}", subject, e);
-            throw new IamException("Zitadel 사용자 조회 중 예외 발생: " + e.getMessage(), e);
         }
+
+        throw new IamException("사용자 email을 찾을 수 없습니다: subject=" + subject);
     }
 
     /**
      * Authorization ID 조회 (헬퍼 메소드)
+     * grantId를 찾아서 Optional로 반환합니다. 검증은 호출하는 쪽에서 담당합니다.
      */
-    private String findAuthorizationId(String userId) throws IamException {
+    private Optional<String> findAuthorizationId(String userId) throws IamException {
         ZitadelAuthorizationDto.ListResponse response = authExecutor.listAuthorizations(userId);
         
         if (response != null && response.authorizations() != null && !response.authorizations().isEmpty()) {
@@ -230,11 +203,11 @@ public class ZitadelClient implements IamClient {
             String grantId = firstGrant.id();
             if (grantId != null && !grantId.isBlank()) {
                 log.debug("Authorization ID 조회 완료: userId={}, grantId={}", userId, grantId);
-                return grantId;
+                return Optional.of(grantId);
             }
         }
 
-        throw new IamException("Grant ID를 찾을 수 없습니다: userId=" + userId);
+        return Optional.empty();
     }
 
     /**

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/ZitadelTokenDecoder.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/ZitadelTokenDecoder.java
@@ -1,0 +1,116 @@
+package io.hlab.OpenConsole.infrastructure.iam.zitadel;
+
+import io.hlab.OpenConsole.infrastructure.iam.IamRole;
+import io.hlab.OpenConsole.infrastructure.iam.IamTokenDecoder;
+import io.hlab.OpenConsole.infrastructure.iam.IamException;
+import io.hlab.OpenConsole.infrastructure.iam.IamUserInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Zitadel JWT 토큰 디코더 구현체
+ * JWT 토큰을 디코딩하여 사용자 정보와 role을 추출
+ * 
+ * 실제 구현은 Spring Security OAuth2 Resource Server가 처리하지만,
+ * 여기서는 토큰에서 role을 추출하는 로직을 제공
+ */
+@Slf4j
+@Component
+public class ZitadelTokenDecoder implements IamTokenDecoder {
+
+    @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
+    private String issuerUri;
+
+    @Override
+    public IamUserInfo decode(String token) throws IamException {
+        log.debug("Zitadel 토큰 디코딩 시작");
+
+        try {
+            // Spring Security OAuth2 Resource Server가 JWT 검증을 처리하므로
+            // 이 메서드는 사용되지 않음. fromClaims() 메서드를 사용하세요.
+            log.warn("ZitadelTokenDecoder.decode()는 사용되지 않습니다. " +
+                    "SecurityContext에서 JwtAuthenticationToken을 사용하거나 fromClaims()를 사용하세요.");
+
+            throw new UnsupportedOperationException(
+                    "ZitadelTokenDecoder.decode()는 사용되지 않습니다. " +
+                    "fromClaims() 메서드를 사용하세요.");
+
+        } catch (Exception e) {
+            log.error("Zitadel 토큰 디코딩 실패", e);
+            throw new IamException("토큰 디코딩 실패: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean isValid(String token) {
+        // Spring Security OAuth2 Resource Server가 자동으로 토큰 유효성 검증 처리
+        // 이 메서드는 현재 사용되지 않음
+        return true;
+    }
+
+    /**
+     * JWT claims에서 IamUserInfo 생성
+     * SecurityContext에서 가져온 JWT claims를 IamUserInfo로 변환
+     * 
+     * @param claims JWT claims (Map<String, Object>)
+     * @return IamUserInfo
+     */
+    @Override
+    public IamUserInfo fromClaims(Map<String, Object> claims) {
+        String subject = (String) claims.get("sub");
+        String email = (String) claims.get("email");
+        String name = (String) claims.get("name");
+
+        // Zitadel의 role은 보통 "roles" 또는 "urn:zitadel:iam:org:project:roles" 클레임에 있음
+        List<IamRole> roles = extractRoles(claims);
+
+        return IamUserInfo.of(subject, email, name, roles);
+    }
+
+    /**
+     * JWT claims에서 role 목록 추출
+     * 
+     * @param claims JWT claims
+     * @return role 목록
+     */
+    private static List<IamRole> extractRoles(Map<String, Object> claims) {
+        List<IamRole> roles = new ArrayList<>();
+
+        // Zitadel의 role 클레임 위치 확인 필요
+        // 일반적으로 "roles" 또는 "urn:zitadel:iam:org:project:roles" 형태
+        Object rolesClaim = claims.get("roles");
+        if (rolesClaim instanceof List) {
+            ((List<?>) rolesClaim).forEach(role -> {
+                if (role instanceof String) {
+                    IamRole iamRole = IamRole.fromString((String) role);
+                    if (iamRole != null) {
+                        roles.add(iamRole);
+                    }
+                }
+            });
+        }
+
+        // 다른 형태의 role 클레임도 확인
+        // 예: "urn:zitadel:iam:org:project:roles" 형태
+        claims.forEach((key, value) -> {
+            if (key.contains("roles") && value instanceof List) {
+                ((List<?>) value).forEach(role -> {
+                    if (role instanceof String) {
+                        IamRole iamRole = IamRole.fromString((String) role);
+                        if (iamRole != null && !roles.contains(iamRole)) {
+                            roles.add(iamRole);
+                        }
+                    }
+                });
+            }
+        });
+
+        return roles;
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/client/ZitadelAuthExecutor.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/client/ZitadelAuthExecutor.java
@@ -14,6 +14,8 @@ import java.util.List;
 /**
  * Zitadel Authorization v2 API 실행자
  * Authorization 관련 API 호출만 담당
+ * 
+ * <p>테스트 환경에서는 실제 Zitadel 서버가 없으므로 모킹하여 사용합니다.
  */
 @Slf4j
 @Component
@@ -38,8 +40,13 @@ public class ZitadelAuthExecutor {
      * WebClient 인스턴스 생성 (공통 헤더 설정)
      */
     private WebClient createWebClient() {
+        // domain에 프로토콜이 이미 포함되어 있으면 그대로 사용, 없으면 https:// 추가
+        String baseUrl = zitadelDomain.startsWith("http://") || zitadelDomain.startsWith("https://")
+                ? zitadelDomain
+                : "https://" + zitadelDomain;
+        
         return webClientBuilder
-                .baseUrl("https://" + zitadelDomain)
+                .baseUrl(baseUrl)
                 .defaultHeader("Authorization", "Bearer " + apiToken)
                 .defaultHeader("Content-Type", "application/json")
                 .defaultHeader("Connect-Protocol-Version", "1")

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/client/ZitadelAuthExecutor.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/client/ZitadelAuthExecutor.java
@@ -40,6 +40,11 @@ public class ZitadelAuthExecutor {
      * WebClient 인스턴스 생성 (공통 헤더 설정)
      */
     private WebClient createWebClient() {
+        // domain이 null이거나 빈 문자열인 경우 처리
+        if (zitadelDomain == null || zitadelDomain.isBlank()) {
+            throw new IllegalStateException("zitadel.domain이 설정되지 않았습니다. application.yaml 또는 환경 변수를 확인하세요.");
+        }
+        
         // domain에 프로토콜이 이미 포함되어 있으면 그대로 사용, 없으면 https:// 추가
         String baseUrl = zitadelDomain.startsWith("http://") || zitadelDomain.startsWith("https://")
                 ? zitadelDomain

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/client/ZitadelAuthExecutor.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/client/ZitadelAuthExecutor.java
@@ -1,0 +1,235 @@
+package io.hlab.OpenConsole.infrastructure.iam.zitadel.client;
+
+import io.hlab.OpenConsole.infrastructure.iam.IamException;
+import io.hlab.OpenConsole.infrastructure.iam.zitadel.dto.ZitadelAuthorizationDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.List;
+
+/**
+ * Zitadel Authorization v2 API 실행자
+ * Authorization 관련 API 호출만 담당
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ZitadelAuthExecutor {
+
+    @Value("${zitadel.domain}")
+    private String zitadelDomain;
+
+    @Value("${zitadel.org-id}")
+    private String orgId;
+
+    @Value("${zitadel.project-id}")
+    private String projectId;
+
+    @Value("${zitadel.api-token}")
+    private String apiToken;
+
+    private final WebClient.Builder webClientBuilder;
+
+    /**
+     * WebClient 인스턴스 생성 (공통 헤더 설정)
+     */
+    private WebClient createWebClient() {
+        return webClientBuilder
+                .baseUrl("https://" + zitadelDomain)
+                .defaultHeader("Authorization", "Bearer " + apiToken)
+                .defaultHeader("Content-Type", "application/json")
+                .defaultHeader("Connect-Protocol-Version", "1")
+                .build();
+    }
+
+    /**
+     * Zitadel Authorization 생성 (CreateAuthorization)
+     * user의 Authorization이 이미 존재하는 경우엔 오류 발생 (409 Conflict 였던 것 같음)
+     */
+    public ZitadelAuthorizationDto.CreateResponse createAuthorization(String userId, List<String> roleKeys) throws IamException {
+        WebClient webClient = createWebClient();
+        
+        ZitadelAuthorizationDto.CreateRequest request = new ZitadelAuthorizationDto.CreateRequest(
+                userId,
+                projectId,
+                orgId,
+                roleKeys
+        );
+
+        try {
+            ZitadelAuthorizationDto.CreateResponse response = webClient.post()
+                    .uri("/zitadel.authorization.v2.AuthorizationService/CreateAuthorization")
+                    .header("x-zitadel-orgid", this.orgId)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(ZitadelAuthorizationDto.CreateResponse.class)
+                    .block();
+
+            log.debug("Authorization 생성 완료: userId={}, roleKeys={}", userId, roleKeys);
+            return response;
+        } catch (WebClientResponseException e) {
+            log.error("Authorization 생성 실패: userId={}, roleKeys={}, status={}, body={}",
+                    userId, roleKeys, e.getStatusCode(), e.getResponseBodyAsString());
+            throw new IamException("Authorization 생성 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Zitadel Authorization 업데이트 (UpdateAuthorization)
+     */
+    public ZitadelAuthorizationDto.UpdateResponse updateAuthorization(String grantId, List<String> roleKeys) throws IamException {
+        WebClient webClient = createWebClient();
+        
+        ZitadelAuthorizationDto.UpdateRequest request = new ZitadelAuthorizationDto.UpdateRequest(
+                grantId,
+                roleKeys
+        );
+
+        try {
+            ZitadelAuthorizationDto.UpdateResponse response = webClient.post()
+                    .uri("/zitadel.authorization.v2.AuthorizationService/UpdateAuthorization")
+                    .header("x-zitadel-orgid", this.orgId)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(ZitadelAuthorizationDto.UpdateResponse.class)
+                    .block();
+
+            log.debug("Authorization 업데이트 완료: grantId={}, roleKeys={}", grantId, roleKeys);
+            return response;
+        } catch (WebClientResponseException e) {
+            log.error("Authorization 업데이트 실패: grantId={}, roleKeys={}, status={}, body={}",
+                    grantId, roleKeys, e.getStatusCode(), e.getResponseBodyAsString());
+            throw new IamException("Authorization 업데이트 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Zitadel Authorization 목록 조회 (ListAuthorizations)
+     */
+    public ZitadelAuthorizationDto.ListResponse listAuthorizations(String userId) throws IamException {
+        WebClient webClient = createWebClient();
+        
+        ZitadelAuthorizationDto.ListRequest.PaginationRequest pagination = 
+                new ZitadelAuthorizationDto.ListRequest.PaginationRequest(100, null, true);
+        
+        ZitadelAuthorizationDto.ListRequest.AuthorizationsSearchFilter.InUserIdsFilter inUserIdsFilter = 
+                new ZitadelAuthorizationDto.ListRequest.AuthorizationsSearchFilter.InUserIdsFilter(List.of(userId));
+        
+        ZitadelAuthorizationDto.ListRequest.AuthorizationsSearchFilter.ProjectIdFilter projectIdFilter = 
+                new ZitadelAuthorizationDto.ListRequest.AuthorizationsSearchFilter.ProjectIdFilter(projectId);
+        
+        ZitadelAuthorizationDto.ListRequest.AuthorizationsSearchFilter.OrganizationIdFilter orgIdFilter = 
+                new ZitadelAuthorizationDto.ListRequest.AuthorizationsSearchFilter.OrganizationIdFilter(orgId);
+        
+        ZitadelAuthorizationDto.ListRequest.AuthorizationsSearchFilter filter1 = 
+                new ZitadelAuthorizationDto.ListRequest.AuthorizationsSearchFilter(
+                        null, inUserIdsFilter, null, null, projectIdFilter, null, null, null, null, null, null);
+        
+        ZitadelAuthorizationDto.ListRequest.AuthorizationsSearchFilter filter2 = 
+                new ZitadelAuthorizationDto.ListRequest.AuthorizationsSearchFilter(
+                        null, null, orgIdFilter, null, null, null, null, null, null, null, null);
+        
+        ZitadelAuthorizationDto.ListRequest request = new ZitadelAuthorizationDto.ListRequest(
+                pagination,
+                ZitadelAuthorizationDto.ListRequest.AuthorizationFieldName.AUTHORIZATION_FIELD_NAME_UNSPECIFIED,
+                List.of(filter1, filter2)
+        );
+
+        try {
+            return webClient.post()
+                    .uri("/zitadel.authorization.v2.AuthorizationService/ListAuthorizations")
+                    .header("x-zitadel-orgid", this.orgId)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(ZitadelAuthorizationDto.ListResponse.class)
+                    .block();
+        } catch (WebClientResponseException e) {
+            log.error("Authorization 목록 조회 실패: userId={}, status={}, body={}",
+                    userId, e.getStatusCode(), e.getResponseBodyAsString());
+            throw new IamException("Authorization 목록 조회 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Zitadel Authorization 삭제 (DeleteAuthorization)
+     */
+    public ZitadelAuthorizationDto.DeleteResponse deleteAuthorization(String grantId) throws IamException {
+        WebClient webClient = createWebClient();
+        
+        ZitadelAuthorizationDto.DeleteRequest request = new ZitadelAuthorizationDto.DeleteRequest(grantId);
+
+        try {
+            ZitadelAuthorizationDto.DeleteResponse response = webClient.post()
+                    .uri("/zitadel.authorization.v2.AuthorizationService/DeleteAuthorization")
+                    .header("x-zitadel-orgid", this.orgId)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(ZitadelAuthorizationDto.DeleteResponse.class)
+                    .block();
+
+            log.debug("Authorization 삭제 완료: grantId={}", grantId);
+            return response;
+        } catch (WebClientResponseException e) {
+            log.error("Authorization 삭제 실패: grantId={}, status={}, body={}",
+                    grantId, e.getStatusCode(), e.getResponseBodyAsString());
+            throw new IamException("Authorization 삭제 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Zitadel Authorization 활성화 (ActivateAuthorization)
+     */
+    public ZitadelAuthorizationDto.ActivateResponse activateAuthorization(String grantId) throws IamException {
+        WebClient webClient = createWebClient();
+        
+        ZitadelAuthorizationDto.ActivateRequest request = new ZitadelAuthorizationDto.ActivateRequest(grantId);
+
+        try {
+            ZitadelAuthorizationDto.ActivateResponse response = webClient.post()
+                    .uri("/zitadel.authorization.v2.AuthorizationService/ActivateAuthorization")
+                    .header("x-zitadel-orgid", this.orgId)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(ZitadelAuthorizationDto.ActivateResponse.class)
+                    .block();
+
+            log.debug("Authorization 활성화 완료: grantId={}", grantId);
+            return response;
+        } catch (WebClientResponseException e) {
+            log.error("Authorization 활성화 실패: grantId={}, status={}, body={}",
+                    grantId, e.getStatusCode(), e.getResponseBodyAsString());
+            throw new IamException("Authorization 활성화 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Zitadel Authorization 비활성화 (DeactivateAuthorization)
+     */
+    public ZitadelAuthorizationDto.DeactivateResponse deactivateAuthorization(String grantId) throws IamException {
+        WebClient webClient = createWebClient();
+        
+        ZitadelAuthorizationDto.DeactivateRequest request = new ZitadelAuthorizationDto.DeactivateRequest(grantId);
+
+        try {
+            ZitadelAuthorizationDto.DeactivateResponse response = webClient.post()
+                    .uri("/zitadel.authorization.v2.AuthorizationService/DeactivateAuthorization")
+                    .header("x-zitadel-orgid", this.orgId)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(ZitadelAuthorizationDto.DeactivateResponse.class)
+                    .block();
+
+            log.debug("Authorization 비활성화 완료: grantId={}", grantId);
+            return response;
+        } catch (WebClientResponseException e) {
+            log.error("Authorization 비활성화 실패: grantId={}, status={}, body={}",
+                    grantId, e.getStatusCode(), e.getResponseBodyAsString());
+            throw new IamException("Authorization 비활성화 실패: " + e.getMessage(), e);
+        }
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/client/ZitadelUserExecutor.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/client/ZitadelUserExecutor.java
@@ -36,6 +36,11 @@ public class ZitadelUserExecutor {
      * WebClient 인스턴스 생성 (공통 헤더 설정)
      */
     private WebClient createWebClient() {
+        // domain이 null이거나 빈 문자열인 경우 처리
+        if (zitadelDomain == null || zitadelDomain.isBlank()) {
+            throw new IllegalStateException("zitadel.domain이 설정되지 않았습니다. application.yaml 또는 환경 변수를 확인하세요.");
+        }
+        
         // domain에 프로토콜이 이미 포함되어 있으면 그대로 사용, 없으면 https:// 추가
         String baseUrl = zitadelDomain.startsWith("http://") || zitadelDomain.startsWith("https://")
                 ? zitadelDomain

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/client/ZitadelUserExecutor.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/client/ZitadelUserExecutor.java
@@ -1,0 +1,323 @@
+package io.hlab.OpenConsole.infrastructure.iam.zitadel.client;
+
+import io.hlab.OpenConsole.infrastructure.iam.IamException;
+import io.hlab.OpenConsole.infrastructure.iam.zitadel.dto.ZitadelUserDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Zitadel User v2 API 실행자
+ * User 관련 API 호출만 담당
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ZitadelUserExecutor {
+
+    @Value("${zitadel.domain}")
+    private String zitadelDomain;
+
+    @Value("${zitadel.org-id}")
+    private String orgId;
+
+    @Value("${zitadel.api-token}")
+    private String apiToken;
+
+    private final WebClient.Builder webClientBuilder;
+
+    /**
+     * WebClient 인스턴스 생성 (공통 헤더 설정)
+     */
+    private WebClient createWebClient() {
+        return webClientBuilder
+                .baseUrl("https://" + zitadelDomain)
+                .defaultHeader("Authorization", "Bearer " + apiToken)
+                .defaultHeader("Content-Type", "application/json")
+                .defaultHeader("Connect-Protocol-Version", "1")
+                .build();
+    }
+
+    /**
+     * Zitadel 사용자 목록 조회 (ListUsers)
+     * POST /v2/users
+     */
+    public ZitadelUserDto.ListUsersResponse listUsers(
+            Integer offset, Integer limit, Boolean asc,
+            String sortingColumn, List<Map<String, Object>> queries) throws IamException {
+        WebClient webClient = createWebClient();
+
+        ZitadelUserDto.ListUsersRequest.Query query = new ZitadelUserDto.ListUsersRequest.Query(
+                offset, limit, asc
+        );
+
+        ZitadelUserDto.ListUsersRequest request = new ZitadelUserDto.ListUsersRequest(
+                query, sortingColumn, queries
+        );
+
+        try {
+            return webClient.post()
+                    .uri("/v2/users")
+                    .header("x-zitadel-orgid", this.orgId)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(ZitadelUserDto.ListUsersResponse.class)
+                    .block();
+        } catch (WebClientResponseException e) {
+            log.error("사용자 목록 조회 실패: status={}, body={}",
+                    e.getStatusCode(), e.getResponseBodyAsString());
+            throw new IamException("사용자 목록 조회 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Email로 사용자 검색 (ListUsers의 헬퍼 메소드)
+     */
+    public ZitadelUserDto.ListUsersResponse.User findUserByEmail(String email) throws IamException {
+        List<Map<String, Object>> queries = List.of(
+                Map.of("emailQuery", Map.of(
+                        "emailAddress", email,
+                        "method", "TEXT_QUERY_METHOD_EQUALS"
+                ))
+        );
+
+        ZitadelUserDto.ListUsersResponse response = listUsers(0, 100, true, null, queries);
+
+        if (response != null && response.result() != null && !response.result().isEmpty()) {
+            return response.result().get(0);
+        }
+
+        throw new IamException("사용자를 찾을 수 없습니다: email=" + email);
+    }
+
+    /**
+     * Zitadel 사용자 ID로 조회 (GetUserByID)
+     * GET /v2/users/{user_id}
+     */
+    public ZitadelUserDto.GetUserByIDResponse getUserByID(String userId) throws IamException {
+        WebClient webClient = createWebClient();
+
+        try {
+            return webClient.get()
+                    .uri("/v2/users/{user_id}", userId)
+                    .header("x-zitadel-orgid", this.orgId)
+                    .retrieve()
+                    .bodyToMono(ZitadelUserDto.GetUserByIDResponse.class)
+                    .block();
+        } catch (WebClientResponseException e) {
+            log.error("사용자 조회 실패: userId={}, status={}, body={}",
+                    userId, e.getStatusCode(), e.getResponseBodyAsString());
+            
+            if (e.getStatusCode().value() == 404) {
+                throw new IamException("사용자를 찾을 수 없습니다: userId=" + userId, e);
+            }
+            throw new IamException("사용자 조회 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Zitadel 사용자 생성 (CreateUser - Human)
+     * POST /v2/users/new
+     */
+    public ZitadelUserDto.CreateUserResponse createUser(ZitadelUserDto.CreateUserRequest request) throws IamException {
+        WebClient webClient = createWebClient();
+
+        try {
+            ZitadelUserDto.CreateUserResponse response = webClient.post()
+                    .uri("/v2/users/new")
+                    .header("x-zitadel-orgid", this.orgId)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(ZitadelUserDto.CreateUserResponse.class)
+                    .block();
+
+            log.debug("사용자 생성 완료: userId={}", response.id());
+            return response;
+        } catch (WebClientResponseException e) {
+            log.error("사용자 생성 실패: status={}, body={}",
+                    e.getStatusCode(), e.getResponseBodyAsString());
+            throw new IamException("사용자 생성 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Zitadel 사용자 삭제 (DeleteUser)
+     * DELETE /v2/users/{user_id}
+     */
+    public ZitadelUserDto.DeleteUserResponse deleteUser(String userId) throws IamException {
+        WebClient webClient = createWebClient();
+
+        try {
+            ZitadelUserDto.DeleteUserResponse response = webClient.delete()
+                    .uri("/v2/users/{user_id}", userId)
+                    .header("x-zitadel-orgid", this.orgId)
+                    .retrieve()
+                    .bodyToMono(ZitadelUserDto.DeleteUserResponse.class)
+                    .block();
+
+            log.debug("사용자 삭제 완료: userId={}", userId);
+            return response;
+        } catch (WebClientResponseException e) {
+            log.error("사용자 삭제 실패: userId={}, status={}, body={}",
+                    userId, e.getStatusCode(), e.getResponseBodyAsString());
+            
+            if (e.getStatusCode().value() == 404) {
+                throw new IamException("사용자를 찾을 수 없습니다: userId=" + userId, e);
+            }
+            throw new IamException("사용자 삭제 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Zitadel 사용자 비활성화 (DeactivateUser)
+     * POST /v2/users/{user_id}/deactivate
+     */
+    public ZitadelUserDto.DeactivateUserResponse deactivateUser(String userId) throws IamException {
+        WebClient webClient = createWebClient();
+
+        try {
+            ZitadelUserDto.DeactivateUserResponse response = webClient.post()
+                    .uri("/v2/users/{user_id}/deactivate", userId)
+                    .header("x-zitadel-orgid", this.orgId)
+                    .retrieve()
+                    .bodyToMono(ZitadelUserDto.DeactivateUserResponse.class)
+                    .block();
+
+            log.debug("사용자 비활성화 완료: userId={}", userId);
+            return response;
+        } catch (WebClientResponseException e) {
+            log.error("사용자 비활성화 실패: userId={}, status={}, body={}",
+                    userId, e.getStatusCode(), e.getResponseBodyAsString());
+            
+            if (e.getStatusCode().value() == 404) {
+                throw new IamException("사용자를 찾을 수 없습니다: userId=" + userId, e);
+            }
+            throw new IamException("사용자 비활성화 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Zitadel 사용자 메타데이터 설정 (SetUserMetadata)
+     * POST /v2/users/{user_id}/metadata
+     */
+    public ZitadelUserDto.SetUserMetadataResponse setUserMetadata(
+            String userId, List<ZitadelUserDto.SetUserMetadataRequest.Metadata> metadata) throws IamException {
+        WebClient webClient = createWebClient();
+
+        ZitadelUserDto.SetUserMetadataRequest request = new ZitadelUserDto.SetUserMetadataRequest(metadata);
+
+        try {
+            ZitadelUserDto.SetUserMetadataResponse response = webClient.post()
+                    .uri("/v2/users/{user_id}/metadata", userId)
+                    .header("x-zitadel-orgid", this.orgId)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(ZitadelUserDto.SetUserMetadataResponse.class)
+                    .block();
+
+            log.debug("사용자 메타데이터 설정 완료: userId={}", userId);
+            return response;
+        } catch (WebClientResponseException e) {
+            log.error("사용자 메타데이터 설정 실패: userId={}, status={}, body={}",
+                    userId, e.getStatusCode(), e.getResponseBodyAsString());
+            
+            if (e.getStatusCode().value() == 404) {
+                throw new IamException("사용자를 찾을 수 없습니다: userId=" + userId, e);
+            }
+            throw new IamException("사용자 메타데이터 설정 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Zitadel 사용자 잠금 (LockUser)
+     * POST /v2/users/{user_id}/lock
+     */
+    public ZitadelUserDto.LockUserResponse lockUser(String userId) throws IamException {
+        WebClient webClient = createWebClient();
+
+        try {
+            ZitadelUserDto.LockUserResponse response = webClient.post()
+                    .uri("/v2/users/{user_id}/lock", userId)
+                    .header("x-zitadel-orgid", this.orgId)
+                    .retrieve()
+                    .bodyToMono(ZitadelUserDto.LockUserResponse.class)
+                    .block();
+
+            log.debug("사용자 잠금 완료: userId={}", userId);
+            return response;
+        } catch (WebClientResponseException e) {
+            log.error("사용자 잠금 실패: userId={}, status={}, body={}",
+                    userId, e.getStatusCode(), e.getResponseBodyAsString());
+            
+            if (e.getStatusCode().value() == 404) {
+                throw new IamException("사용자를 찾을 수 없습니다: userId=" + userId, e);
+            }
+            throw new IamException("사용자 잠금 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Zitadel 사용자 잠금 해제 (UnlockUser)
+     * POST /v2/users/{user_id}/unlock
+     */
+    public ZitadelUserDto.UnlockUserResponse unlockUser(String userId) throws IamException {
+        WebClient webClient = createWebClient();
+
+        try {
+            ZitadelUserDto.UnlockUserResponse response = webClient.post()
+                    .uri("/v2/users/{user_id}/unlock", userId)
+                    .header("x-zitadel-orgid", this.orgId)
+                    .retrieve()
+                    .bodyToMono(ZitadelUserDto.UnlockUserResponse.class)
+                    .block();
+
+            log.debug("사용자 잠금 해제 완료: userId={}", userId);
+            return response;
+        } catch (WebClientResponseException e) {
+            log.error("사용자 잠금 해제 실패: userId={}, status={}, body={}",
+                    userId, e.getStatusCode(), e.getResponseBodyAsString());
+            
+            if (e.getStatusCode().value() == 404) {
+                throw new IamException("사용자를 찾을 수 없습니다: userId=" + userId, e);
+            }
+            throw new IamException("사용자 잠금 해제 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Zitadel 초대 코드 생성 (CreateInviteCode)
+     * POST /v2/users/{user_id}/invite_code
+     */
+    public ZitadelUserDto.CreateInviteCodeResponse createInviteCode(
+            String userId, ZitadelUserDto.CreateInviteCodeRequest request) throws IamException {
+        WebClient webClient = createWebClient();
+
+        try {
+            ZitadelUserDto.CreateInviteCodeResponse response = webClient.post()
+                    .uri("/v2/users/{user_id}/invite_code", userId)
+                    .header("x-zitadel-orgid", this.orgId)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(ZitadelUserDto.CreateInviteCodeResponse.class)
+                    .block();
+
+            log.debug("초대 코드 생성 완료: userId={}", userId);
+            return response;
+        } catch (WebClientResponseException e) {
+            log.error("초대 코드 생성 실패: userId={}, status={}, body={}",
+                    userId, e.getStatusCode(), e.getResponseBodyAsString());
+            
+            if (e.getStatusCode().value() == 404) {
+                throw new IamException("사용자를 찾을 수 없습니다: userId=" + userId, e);
+            }
+            throw new IamException("초대 코드 생성 실패: " + e.getMessage(), e);
+        }
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/client/ZitadelUserExecutor.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/client/ZitadelUserExecutor.java
@@ -36,8 +36,13 @@ public class ZitadelUserExecutor {
      * WebClient 인스턴스 생성 (공통 헤더 설정)
      */
     private WebClient createWebClient() {
+        // domain에 프로토콜이 이미 포함되어 있으면 그대로 사용, 없으면 https:// 추가
+        String baseUrl = zitadelDomain.startsWith("http://") || zitadelDomain.startsWith("https://")
+                ? zitadelDomain
+                : "https://" + zitadelDomain;
+        
         return webClientBuilder
-                .baseUrl("https://" + zitadelDomain)
+                .baseUrl(baseUrl)
                 .defaultHeader("Authorization", "Bearer " + apiToken)
                 .defaultHeader("Content-Type", "application/json")
                 .defaultHeader("Connect-Protocol-Version", "1")

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/dto/ZitadelAuthorizationDto.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/dto/ZitadelAuthorizationDto.java
@@ -1,0 +1,158 @@
+package io.hlab.OpenConsole.infrastructure.iam.zitadel.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Zitadel Authorization v2 API DTOs
+ * 모든 Authorization 관련 Request/Response를 record로 정의
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ZitadelAuthorizationDto {
+
+    // ==================== ListAuthorizations ====================
+    
+    public record ListRequest(
+            PaginationRequest pagination,
+            @JsonProperty("sortingColumn") AuthorizationFieldName sortingColumn,
+            List<AuthorizationsSearchFilter> filters
+    ) {
+        public record PaginationRequest(
+                Integer limit,
+                Integer offset,
+                Boolean asc
+        ) {}
+
+        public enum AuthorizationFieldName {
+            AUTHORIZATION_FIELD_NAME_UNSPECIFIED,
+            AUTHORIZATION_FIELD_NAME_CREATION_DATE,
+            AUTHORIZATION_FIELD_NAME_CHANGE_DATE
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_NULL) // 보낼 때: null 필드 제외
+        @JsonIgnoreProperties(ignoreUnknown = true) // 받을 때: 모르는 필드 무시 (안전장치)
+        public record AuthorizationsSearchFilter(
+                AuthorizationIdsFilter authorizationIds,
+                InUserIdsFilter inUserIds,
+                OrganizationIdFilter organizationId,
+                ProjectGrantIdFilter projectGrantId,
+                ProjectIdFilter projectId,
+                ProjectNameFilter projectName,
+                RoleKeyFilter roleKey,
+                StateFilter state,
+                UserDisplayNameFilter userDisplayName,
+                UserOrganizationIdFilter userOrganizationId,
+                UserPreferredLoginNameFilter userPreferredLoginName
+        ) {
+            public record AuthorizationIdsFilter(List<String> ids) {}
+            public record InUserIdsFilter(List<String> ids) {}
+            public record OrganizationIdFilter(String id) {}
+            public record ProjectGrantIdFilter(String id) {}
+            public record ProjectIdFilter(String id) {}
+            public record ProjectNameFilter(String name, TextFilterMethod method) {}
+            public record RoleKeyFilter(String key, TextFilterMethod method) {}
+            public record StateFilter(AuthorizationState state) {}
+            public record UserDisplayNameFilter(String displayName, TextFilterMethod method) {}
+            public record UserOrganizationIdFilter(String id) {}
+            public record UserPreferredLoginNameFilter(String loginName, TextFilterMethod method) {}
+        }
+
+        public enum TextFilterMethod {
+            TEXT_FILTER_METHOD_EQUALS,
+            TEXT_FILTER_METHOD_EQUALS_IGNORE_CASE,
+            TEXT_FILTER_METHOD_STARTS_WITH,
+            TEXT_FILTER_METHOD_STARTS_WITH_IGNORE_CASE,
+            TEXT_FILTER_METHOD_CONTAINS,
+            TEXT_FILTER_METHOD_CONTAINS_IGNORE_CASE,
+            TEXT_FILTER_METHOD_ENDS_WITH,
+            TEXT_FILTER_METHOD_ENDS_WITH_IGNORE_CASE
+        }
+
+        public enum AuthorizationState {
+            AUTHORIZATION_STATE_UNSPECIFIED,
+            AUTHORIZATION_STATE_ACTIVE,
+            AUTHORIZATION_STATE_INACTIVE
+        }
+    }
+
+    public record ListResponse(
+            PaginationResponse pagination,
+            List<Authorization> authorizations
+    ) {
+        public record PaginationResponse(
+                Integer limit,
+                Integer offset,
+                Long totalResult
+        ) {}
+
+        public record Authorization(
+                String id,
+                @JsonProperty("userId") String userId,
+                @JsonProperty("projectId") String projectId,
+                @JsonProperty("organizationId") String organizationId,
+                @JsonProperty("roleKeys") List<String> roleKeys,
+                String state,
+                String creationDate,
+                String changeDate
+        ) {}
+    }
+
+    // ==================== CreateAuthorization ====================
+    
+    public record CreateRequest(
+            @JsonProperty("userId") String userId,
+            @JsonProperty("projectId") String projectId,
+            @JsonProperty("organizationId") String organizationId,
+            @JsonProperty("roleKeys") List<String> roleKeys
+    ) {}
+
+    public record CreateResponse(
+            String id,
+            String creationDate
+    ) {}
+
+    // ==================== UpdateAuthorization ====================
+    
+    public record UpdateRequest(
+            String id,
+            @JsonProperty("roleKeys") List<String> roleKeys
+    ) {}
+
+    public record UpdateResponse(
+            String changeDate
+    ) {}
+
+    // ==================== DeleteAuthorization ====================
+    
+    public record DeleteRequest(
+            String id
+    ) {}
+
+    public record DeleteResponse(
+            String deletionDate
+    ) {}
+
+    // ==================== ActivateAuthorization ====================
+    
+    public record ActivateRequest(
+            String id
+    ) {}
+
+    public record ActivateResponse(
+            String changeDate
+    ) {}
+
+    // ==================== DeactivateAuthorization ====================
+    
+    public record DeactivateRequest(
+            String id
+    ) {}
+
+    public record DeactivateResponse(
+            String changeDate
+    ) {}
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/dto/ZitadelRoleResponse.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/dto/ZitadelRoleResponse.java
@@ -1,0 +1,26 @@
+package io.hlab.OpenConsole.infrastructure.iam.zitadel.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Zitadel Management API Role 응답 DTO
+ */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ZitadelRoleResponse {
+    private List<ZitadelRole> result;
+    
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ZitadelRole {
+        private String roleKey;
+        private String projectId;
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/dto/ZitadelUserDto.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/dto/ZitadelUserDto.java
@@ -1,0 +1,207 @@
+package io.hlab.OpenConsole.infrastructure.iam.zitadel.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Zitadel User v2 API DTOs
+ * 모든 User 관련 Request/Response를 record로 정의
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ZitadelUserDto {
+
+    // ==================== ListUsers ====================
+    
+    public record ListUsersRequest(
+            @JsonProperty("query") Query query,
+            @JsonProperty("sortingColumn") String sortingColumn,
+            @JsonProperty("queries") List<Map<String, Object>> queries
+    ) {
+        public record Query(
+                Integer offset,
+                Integer limit,
+                Boolean asc
+        ) {}
+    }
+
+    public record ListUsersResponse(
+            @JsonProperty("details") Details details,
+            @JsonProperty("sortingColumn") String sortingColumn,
+            @JsonProperty("result") List<User> result
+    ) {
+        public record Details(
+                Long totalResult,
+                Integer processedSequence,
+                Long viewTimestamp
+        ) {}
+        
+        public record User(
+                @JsonProperty("id") String id,
+                @JsonProperty("userId") String userId,
+                @JsonProperty("username") String username,
+                @JsonProperty("state") String state,
+                @JsonProperty("human") Human human,
+                @JsonProperty("machine") Machine machine
+        ) {
+            public record Human(
+                    @JsonProperty("profile") Profile profile,
+                    @JsonProperty("email") Email email,
+                    @JsonProperty("phone") Phone phone
+            ) {
+                public record Profile(
+                        @JsonProperty("givenName") String givenName,
+                        @JsonProperty("familyName") String familyName,
+                        @JsonProperty("displayName") String displayName,
+                        @JsonProperty("preferredLanguage") String preferredLanguage
+                ) {}
+                
+                public record Email(
+                        @JsonProperty("email") String email,
+                        @JsonProperty("isEmailVerified") Boolean isEmailVerified
+                ) {}
+                
+                public record Phone(
+                        @JsonProperty("phone") String phone,
+                        @JsonProperty("isPhoneVerified") Boolean isPhoneVerified
+                ) {}
+            }
+            
+            public record Machine(
+                    @JsonProperty("name") String name,
+                    @JsonProperty("description") String description
+            ) {}
+        }
+    }
+
+    // ==================== GetUserByID ====================
+    
+    public record GetUserByIDResponse(
+            @JsonProperty("details") Details details,
+            @JsonProperty("user") ListUsersResponse.User user
+    ) {
+        public record Details(
+                Long sequence,
+                Long creationDate,
+                Long changeDate,
+                String resourceOwner
+        ) {}
+    }
+
+    // ==================== CreateUser ====================
+    
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record CreateUserRequest(
+            @JsonProperty("organizationId") String organizationId,
+            @JsonProperty("userId") String userId,
+            @JsonProperty("username") String username,
+            @JsonProperty("human") Human human
+    ) {
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public record Human(
+                @JsonProperty("profile") Profile profile,
+                @JsonProperty("email") Email email,
+                @JsonProperty("phone") Phone phone,
+                @JsonProperty("password") Password password
+        ) {
+            public record Profile(
+                    @JsonProperty("givenName") String givenName,
+                    @JsonProperty("familyName") String familyName,
+                    @JsonProperty("displayName") String displayName,
+                    @JsonProperty("preferredLanguage") String preferredLanguage
+            ) {}
+            
+            public record Email(
+                    @JsonProperty("email") String email,
+                    @JsonProperty("isEmailVerified") Boolean isEmailVerified,
+                    @JsonProperty("sendCode") SendCode sendCode,
+                    @JsonProperty("returnCode") ReturnCode returnCode
+            ) {
+                public record SendCode(
+                        @JsonProperty("urlTemplate") String urlTemplate
+                ) {}
+                
+                public record ReturnCode() {}
+            }
+            
+            public record Phone(
+                    @JsonProperty("phone") String phone,
+                    @JsonProperty("isPhoneVerified") Boolean isPhoneVerified
+            ) {}
+            
+            public record Password(
+                    @JsonProperty("password") String password,
+                    @JsonProperty("changeRequired") Boolean changeRequired
+            ) {}
+        }
+    }
+
+    public record CreateUserResponse(
+            @JsonProperty("id") String id,
+            @JsonProperty("creationDate") String creationDate,
+            @JsonProperty("emailCode") String emailCode,
+            @JsonProperty("phoneCode") String phoneCode
+    ) {}
+
+    // ==================== DeleteUser ====================
+    
+    public record DeleteUserResponse(
+            @JsonProperty("details") GetUserByIDResponse.Details details
+    ) {}
+
+    // ==================== DeactivateUser ====================
+    
+    public record DeactivateUserResponse(
+            @JsonProperty("details") GetUserByIDResponse.Details details
+    ) {}
+
+    // ==================== LockUser ====================
+    
+    public record LockUserResponse(
+            @JsonProperty("details") GetUserByIDResponse.Details details
+    ) {}
+
+    // ==================== UnlockUser ====================
+    
+    public record UnlockUserResponse(
+            @JsonProperty("details") GetUserByIDResponse.Details details
+    ) {}
+
+    // ==================== SetUserMetadata ====================
+    
+    public record SetUserMetadataRequest(
+            @JsonProperty("metadata") List<Metadata> metadata
+    ) {
+        public record Metadata(
+                @JsonProperty("key") String key,
+                @JsonProperty("value") String value  // base64 encoded
+        ) {}
+    }
+
+    public record SetUserMetadataResponse(
+            @JsonProperty("setDate") String setDate
+    ) {}
+
+    // ==================== CreateInviteCode ====================
+    
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record CreateInviteCodeRequest(
+            @JsonProperty("sendCode") SendCode sendCode,
+            @JsonProperty("returnCode") ReturnCode returnCode
+    ) {
+        public record SendCode(
+                @JsonProperty("urlTemplate") String urlTemplate
+        ) {}
+        
+        public record ReturnCode() {}
+    }
+
+    public record CreateInviteCodeResponse(
+            @JsonProperty("details") GetUserByIDResponse.Details details,
+            @JsonProperty("inviteCode") String inviteCode
+    ) {}
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/dto/ZitadelUserResponse.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/iam/zitadel/dto/ZitadelUserResponse.java
@@ -1,0 +1,22 @@
+package io.hlab.OpenConsole.infrastructure.iam.zitadel.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+/**
+ * Zitadel 사용자 조회 응답 DTO
+ */
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ZitadelUserResponse {
+    private ZitadelUserResult result;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ZitadelUserResult {
+        private String id;  // subject
+        private String email;
+        private String userName;
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/persistence/user/SpringDataUserRepository.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/persistence/user/SpringDataUserRepository.java
@@ -1,13 +1,18 @@
 package io.hlab.OpenConsole.infrastructure.persistence.user;
 
+import io.hlab.OpenConsole.domain.user.IamProvider;
 import io.hlab.OpenConsole.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface SpringDataUserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
+    Optional<User> findByProviderAndSubject(IamProvider provider, String subject);
+    
     boolean existsByEmail(String email);
 }
 

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/persistence/user/SpringDataUserRepository.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/persistence/user/SpringDataUserRepository.java
@@ -1,6 +1,5 @@
 package io.hlab.OpenConsole.infrastructure.persistence.user;
 
-import io.hlab.OpenConsole.domain.user.IamProvider;
 import io.hlab.OpenConsole.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,8 +9,6 @@ import java.util.Optional;
 @Repository
 public interface SpringDataUserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
-
-    Optional<User> findByProviderAndSubject(IamProvider provider, String subject);
     
     boolean existsByEmail(String email);
 }

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/persistence/user/UserJpaRepository.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/persistence/user/UserJpaRepository.java
@@ -1,5 +1,6 @@
 package io.hlab.OpenConsole.infrastructure.persistence.user;
 
+import io.hlab.OpenConsole.domain.user.IamProvider;
 import io.hlab.OpenConsole.domain.user.User;
 import io.hlab.OpenConsole.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,11 @@ public class UserJpaRepository implements UserRepository {
     @Override
     public Optional<User> findByEmail(String email) {
         return springDataUserRepository.findByEmail(email);
+    }
+
+    @Override
+    public Optional<User> findByProviderAndSubject(IamProvider provider, String subject) {
+        return springDataUserRepository.findByProviderAndSubject(provider, subject);
     }
 
     @Override

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/persistence/user/UserJpaRepository.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/persistence/user/UserJpaRepository.java
@@ -1,6 +1,5 @@
 package io.hlab.OpenConsole.infrastructure.persistence.user;
 
-import io.hlab.OpenConsole.domain.user.IamProvider;
 import io.hlab.OpenConsole.domain.user.User;
 import io.hlab.OpenConsole.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,11 +25,6 @@ public class UserJpaRepository implements UserRepository {
     @Override
     public Optional<User> findByEmail(String email) {
         return springDataUserRepository.findByEmail(email);
-    }
-
-    @Override
-    public Optional<User> findByProviderAndSubject(IamProvider provider, String subject) {
-        return springDataUserRepository.findByProviderAndSubject(provider, subject);
     }
 
     @Override

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/security/JITUserProvisioningHandler.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/security/JITUserProvisioningHandler.java
@@ -2,67 +2,87 @@ package io.hlab.OpenConsole.infrastructure.security;
 
 import io.hlab.OpenConsole.application.user.UserService;
 import io.hlab.OpenConsole.domain.user.User;
+import io.hlab.OpenConsole.infrastructure.iam.IamClient;
+import io.hlab.OpenConsole.infrastructure.iam.IamException;
+import io.hlab.OpenConsole.infrastructure.iam.IamRole;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import io.hlab.OpenConsole.domain.user.IamProvider;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Optional;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+
+/**
+ * JIT (Just-In-Time) User Provisioning Handler
+ * OAuth2 로그인 성공 시:
+ * 1. DB에 사용자가 없으면 생성
+ * 2. 첫 로그인 시 IAM에 기본 role 부여
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class JITUserProvisioningHandler extends SavedRequestAwareAuthenticationSuccessHandler {
 
     private final UserService userService;
+    private final IamClient iamClient;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
         
-
         // 1. ZITADEL로부터 받은 사용자 정보(OIDC) 꺼내기
         Object principal = authentication.getPrincipal();
         
         if (principal instanceof OidcUser oidcUser) {
-            String sub = oidcUser.getSubject(); // ZITADEL의 고유 ID (sub)
+            String subject = oidcUser.getSubject(); // ZITADEL의 고유 ID (IAM API 호출용)
             String email = oidcUser.getEmail();
-            String name = oidcUser.getFullName();
+            // String name = oidcUser.getFullName(); // Phase 3에서 사용 예정
 
-            // 2. DB에 해당 유저가 있는지 확인 (sub 기준)
-            // 없으면 새로 생성(Provisioning), 있으면 기존 정보 업데이트
-            userService.findUserBySubject(IamProvider.ZITADEL, sub)
-                .map(existingUser -> {
-                    // 필요하다면 여기서 이름이나 이메일 업데이트 로직 추가
-                    log.debug("User already exists: sub={}, email={}", sub, existingUser.getEmail());
-                    return existingUser;
-                })
-                .orElseGet(() -> {
-                    // 처음 로그인한 유저라면 DB에 새로 저장
-                    // email이 없을 경우 sub를 기반으로 기본값 생성 (DB 제약조건 대응)
-                    String userEmail = (email != null && !email.isBlank()) 
-                        ? email 
-                        : sub + "@zitadel.local"; // sub 기반 기본 email
-                    String userName = (name != null && !name.isBlank()) 
-                        ? name 
-                        : userEmail.substring(0, userEmail.indexOf("@"));
-                    
-                    if (email == null || email.isBlank()) {
-                        log.warn("OAuth2 user email is missing. Using sub-based email. sub={}, generatedEmail={}", sub, userEmail);
-                    }
-                    
-                    User newUser = User.create(userEmail, userName, IamProvider.ZITADEL, sub);
-                    return userService.createUser(newUser);
-                });
+            // 2. DB에 해당 유저가 있는지 확인 (email 기준)
+            Optional<User> existingUser = userService.findUserByEmail(email);
+            
+            if (existingUser.isPresent()) {
+                // 기존 사용자: 이름 업데이트만 (필요시)
+                log.debug("User already exists: email={}", email);
+            } else {
+                // 3. 처음 로그인한 유저: DB에 새로 저장
+                String userEmail = (email != null && !email.isBlank()) 
+                    ? email 
+                    : subject + "@zitadel.local"; // email이 없을 경우 (드물지만 방어적 처리)
+                String userName = oidcUser.getFullName();
+                if (userName == null || userName.isBlank()) {
+                    userName = userEmail.substring(0, userEmail.indexOf("@"));
+                }
+                
+                if (email == null || email.isBlank()) {
+                    log.warn("OAuth2 user email is missing. Using subject-based email. subject={}, generatedEmail={}", subject, userEmail);
+                }
+                
+                // DB에 사용자 생성
+                User newUser = User.create(userEmail, userName);
+                User savedUser = userService.createUser(newUser);
+                log.info("New user created: id={}, email={}, subject={}", savedUser.getId(), userEmail, subject);
+                
+                // 4. 첫 로그인 시 IAM에 기본 role 부여
+                // TODO: 기본 role은 설정으로 관리하거나 사용자 입력으로 받을 수 있음
+                // 현재는 userA를 기본 role로 설정
+                try {
+                    iamClient.assignRole(subject, IamRole.USER_A);
+                    log.info("Default role assigned to new user: subject={}, role=userA", subject);
+                } catch (IamException e) {
+                    log.error("Failed to assign default role to new user: subject={}", subject, e);
+                    // role 부여 실패해도 로그인은 성공 처리 (나중에 수동으로 role 부여 가능)
+                }
+            }
         }
 
-        // 3. 원래 가려던 페이지로 리다이렉트 (부모 클래스의 기본 동작)
+        // 5. 원래 가려던 페이지로 리다이렉트 (부모 클래스의 기본 동작)
         super.onAuthenticationSuccess(request, response, authentication);
-
     }
 }

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/security/JITUserProvisioningHandler.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/security/JITUserProvisioningHandler.java
@@ -1,0 +1,68 @@
+package io.hlab.OpenConsole.infrastructure.security;
+
+import io.hlab.OpenConsole.application.user.UserService;
+import io.hlab.OpenConsole.domain.user.User;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import io.hlab.OpenConsole.domain.user.IamProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JITUserProvisioningHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+
+    private final UserService userService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        
+
+        // 1. ZITADEL로부터 받은 사용자 정보(OIDC) 꺼내기
+        Object principal = authentication.getPrincipal();
+        
+        if (principal instanceof OidcUser oidcUser) {
+            String sub = oidcUser.getSubject(); // ZITADEL의 고유 ID (sub)
+            String email = oidcUser.getEmail();
+            String name = oidcUser.getFullName();
+
+            // 2. DB에 해당 유저가 있는지 확인 (sub 기준)
+            // 없으면 새로 생성(Provisioning), 있으면 기존 정보 업데이트
+            userService.findUserBySubject(IamProvider.ZITADEL, sub)
+                .map(existingUser -> {
+                    // 필요하다면 여기서 이름이나 이메일 업데이트 로직 추가
+                    log.debug("User already exists: sub={}, email={}", sub, existingUser.getEmail());
+                    return existingUser;
+                })
+                .orElseGet(() -> {
+                    // 처음 로그인한 유저라면 DB에 새로 저장
+                    // email이 없을 경우 sub를 기반으로 기본값 생성 (DB 제약조건 대응)
+                    String userEmail = (email != null && !email.isBlank()) 
+                        ? email 
+                        : sub + "@zitadel.local"; // sub 기반 기본 email
+                    String userName = (name != null && !name.isBlank()) 
+                        ? name 
+                        : userEmail.substring(0, userEmail.indexOf("@"));
+                    
+                    if (email == null || email.isBlank()) {
+                        log.warn("OAuth2 user email is missing. Using sub-based email. sub={}, generatedEmail={}", sub, userEmail);
+                    }
+                    
+                    User newUser = User.create(userEmail, userName, IamProvider.ZITADEL, sub);
+                    return userService.createUser(newUser);
+                });
+        }
+
+        // 3. 원래 가려던 페이지로 리다이렉트 (부모 클래스의 기본 동작)
+        super.onAuthenticationSuccess(request, response, authentication);
+
+    }
+}

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/security/JITUserProvisioningHandler.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/security/JITUserProvisioningHandler.java
@@ -10,7 +10,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Component;
 
@@ -26,6 +28,7 @@ import org.springframework.security.web.authentication.SavedRequestAwareAuthenti
  */
 @Slf4j
 @Component
+@ConditionalOnBean(ClientRegistrationRepository.class)
 @RequiredArgsConstructor
 public class JITUserProvisioningHandler extends SavedRequestAwareAuthenticationSuccessHandler {
 

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/security/JwtUtils.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/security/JwtUtils.java
@@ -1,0 +1,239 @@
+package io.hlab.OpenConsole.infrastructure.security;
+
+import io.hlab.OpenConsole.infrastructure.iam.IamRole;
+import io.hlab.OpenConsole.infrastructure.iam.IamTokenDecoder;
+import io.hlab.OpenConsole.infrastructure.iam.IamUserInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * JWT 유틸리티
+ * SecurityContext에서 JWT를 읽어서 사용자 정보와 role을 추출
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtUtils {
+
+    private final IamTokenDecoder iamTokenDecoder;
+
+    /**
+     * 현재 SecurityContext에서 JWT를 가져옴
+     * 
+     * @return JWT 또는 null (인증되지 않은 경우)
+     */
+    public Jwt getJwt() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        log.debug("Current authentication type: {}", authentication != null ? authentication.getClass().getName() : "null");
+        
+        if (authentication instanceof JwtAuthenticationToken jwtAuth) {
+            log.debug("JWT found in SecurityContext");
+            return jwtAuth.getToken();
+        }
+        
+        log.warn("JWT not found in SecurityContext. Authentication: {}", authentication);
+        return null;
+    }
+
+    /**
+     * 현재 SecurityContext에서 사용자 정보 추출
+     * 
+     * @return IamUserInfo 또는 null
+     */
+    public IamUserInfo getCurrentUserInfo() {
+        Jwt jwt = getJwt();
+        if (jwt == null) {
+            return null;
+        }
+
+        Map<String, Object> claims = jwt.getClaims();
+        return iamTokenDecoder.fromClaims(claims);
+    }
+
+    /**
+     * 현재 사용자의 email 추출
+     * 
+     * JWT에서 email 클레임을 추출합니다.
+     * 
+     * 참고: JWT에 email이 없는 경우 Zitadel 설정에서 email 클레임을 토큰에 포함하도록 설정해야 합니다.
+     * - Zitadel Console > Project > Application > 해당 클라이언트 > Token Settings
+     * - "User Info" 또는 "Claims" 설정에서 email 클레임 추가
+     * 
+     * @return email 또는 null (JWT에 email이 없는 경우)
+     */
+    public String getCurrentUserEmail() {
+        Jwt jwt = getJwt();
+        if (jwt == null) {
+            log.debug("JWT is null in getCurrentUserEmail");
+            return null;
+        }
+        
+        // 1. JWT에서 직접 email 추출 시도
+        String email = jwt.getClaimAsString("email");
+        log.debug("Extracted email from JWT: {}", email);
+        
+        // 2. JWT에 email이 없으면 다른 클레임에서 찾기 시도 (방어적 프로그래밍)
+        if (email == null) {
+            log.warn("Email claim not found in JWT. Available claims: {}", jwt.getClaims().keySet());
+            
+            // Zitadel의 경우 email이 다른 클레임에 있을 수 있음
+            // 예: "preferred_username", "username" 등
+            email = jwt.getClaimAsString("preferred_username");
+            if (email != null && email.contains("@")) {
+                log.debug("Found email in 'preferred_username' claim: {}", email);
+                return email;
+            }
+            
+            // email이 없으면 null 반환 (Zitadel 설정 확인 필요)
+            log.error("Email not found in JWT. Please configure Zitadel to include email claim in JWT token.");
+        }
+        
+        return email;
+    }
+
+    /**
+     * 현재 사용자의 subject 추출 (IAM API 호출용)
+     * 
+     * @return subject 또는 null
+     */
+    public String getCurrentUserSubject() {
+        Jwt jwt = getJwt();
+        if (jwt == null) {
+            return null;
+        }
+        return jwt.getSubject();
+    }
+
+    /**
+     * 현재 사용자의 role 목록 추출
+     * 
+     * JWT에서 role을 추출합니다.
+     * Zitadel Project role은 OAuth2 scope로 요청하면 JWT에 포함됩니다.
+     * 
+     * @return role 목록
+     */
+    public List<IamRole> getCurrentUserRoles() {
+        Jwt jwt = getJwt();
+        if (jwt == null) {
+            return List.of();
+        }
+
+        Map<String, Object> claims = jwt.getClaims();
+        return extractRoles(claims);
+    }
+
+    /**
+     * JWT claims에서 role 목록 추출
+     * 
+     * Zitadel의 role 클레임은 다음과 같은 형태로 나타날 수 있습니다:
+     * 1. 배열 형태: ["admin", "userA"]
+     * 2. 객체 형태: {"user": {"351864415584321539": "idp.avgmax.team"}}
+     * 
+     * @param claims JWT claims
+     * @return role 목록
+     */
+    @SuppressWarnings("unchecked")
+    private List<IamRole> extractRoles(Map<String, Object> claims) {
+        List<IamRole> roles = new ArrayList<>();
+
+        // 디버깅: 모든 claims 로깅 (실제 환경에서 role 클레임 위치 확인용)
+        log.debug("JWT Claims 전체: {}", claims);
+        
+        // 1. "roles" 클레임 확인 (배열 형태)
+        Object rolesClaim = claims.get("roles");
+        if (rolesClaim instanceof List) {
+            log.debug("Found 'roles' claim (List): {}", rolesClaim);
+            ((List<?>) rolesClaim).forEach(role -> {
+                if (role instanceof String) {
+                    log.debug("Processing role from 'roles' claim: {}", role);
+                    IamRole iamRole = IamRole.fromString((String) role);
+                    if (iamRole != null) {
+                        roles.add(iamRole);
+                        log.debug("Successfully converted role: {} -> {}", role, iamRole);
+                    } else {
+                        log.warn("Failed to convert role: {}", role);
+                    }
+                }
+            });
+        }
+
+        // 2. "urn:zitadel:iam:org:project:roles" 형태의 클레임 확인
+        // 객체 형태: {"user": {"351864415584321539": "idp.avgmax.team"}}
+        log.debug("Checking all claims for role-related keys...");
+        claims.forEach((key, value) -> {
+            if (key.contains("roles") && !key.equals("roles")) {
+                log.info("Found role claim with key '{}': {}", key, value);
+                
+                // 배열 형태 처리
+                if (value instanceof List) {
+                    ((List<?>) value).forEach(role -> {
+                        if (role instanceof String) {
+                            log.debug("Processing role from '{}' claim (List): {}", key, role);
+                            IamRole iamRole = IamRole.fromString((String) role);
+                            if (iamRole != null && !roles.contains(iamRole)) {
+                                roles.add(iamRole);
+                                log.debug("Successfully converted role: {} -> {}", role, iamRole);
+                            } else if (iamRole == null) {
+                                log.warn("Failed to convert role from '{}': {}", key, role);
+                            }
+                        }
+                    });
+                }
+                // 객체 형태 처리: {"user": {"351864415584321539": "idp.avgmax.team"}}
+                else if (value instanceof Map) {
+                    Map<String, Object> roleMap = (Map<String, Object>) value;
+                    roleMap.forEach((roleName, roleValue) -> {
+                        log.debug("Processing role from '{}' claim (Object): roleName={}, roleValue={}", 
+                                key, roleName, roleValue);
+                        IamRole iamRole = IamRole.fromString(roleName);
+                        if (iamRole != null && !roles.contains(iamRole)) {
+                            roles.add(iamRole);
+                            log.debug("Successfully converted role: {} -> {}", roleName, iamRole);
+                        } else if (iamRole == null) {
+                            log.warn("Failed to convert role from '{}': roleName={}", key, roleName);
+                        }
+                    });
+                }
+            }
+        });
+
+        log.info("Extracted roles from JWT: {}", roles);
+        return roles;
+    }
+
+    /**
+     * 현재 사용자가 특정 role을 가지고 있는지 확인
+     * 
+     * @param role 확인할 role
+     * @return role을 가지고 있으면 true
+     */
+    public boolean hasRole(IamRole role) {
+        return getCurrentUserRoles().contains(role);
+    }
+
+    /**
+     * 현재 사용자가 여러 role 중 하나라도 가지고 있는지 확인
+     * 
+     * @param roles 확인할 role 목록
+     * @return 하나라도 가지고 있으면 true
+     */
+    public boolean hasAnyRole(IamRole... roles) {
+        List<IamRole> userRoles = getCurrentUserRoles();
+        for (IamRole role : roles) {
+            if (userRoles.contains(role)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/security/SecurityConfig.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,30 @@
+package io.hlab.OpenConsole.infrastructure.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JITUserProvisioningHandler jitUserProvisioningHandler;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().authenticated() // 모든 요청은 로그인 필요
+            )
+            .oauth2Login(oauth2 -> oauth2
+                .successHandler(jitUserProvisioningHandler) // 로그인 성공 시 우리 DB에 저장!
+            );
+        
+        return http.build();
+    }
+}

--- a/be/src/main/java/io/hlab/OpenConsole/infrastructure/security/SecurityConfig.java
+++ b/be/src/main/java/io/hlab/OpenConsole/infrastructure/security/SecurityConfig.java
@@ -1,15 +1,31 @@
 package io.hlab.OpenConsole.infrastructure.security;
 
+import io.hlab.OpenConsole.infrastructure.iam.IamRole;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
-import lombok.RequiredArgsConstructor;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity // @PreAuthorize 사용을 위해 필요
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -18,13 +34,135 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .authorizeHttpRequests(auth -> auth
-                .anyRequest().authenticated() // 모든 요청은 로그인 필요
+            // 세션을 사용하지 않고 JWT만 사용
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             )
+            // CSRF 비활성화 (JWT 사용 시 불필요)
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                // Swagger UI 및 API 문서는 허용 (테스트용)
+                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
+                // OAuth2 로그인 엔드포인트는 허용
+                .requestMatchers("/login/**", "/oauth2/**").permitAll()
+                // 나머지 모든 요청은 인증 필요
+                .anyRequest().authenticated()
+            )
+            // OAuth2 Client: 로그인 플로우 (FE에서 리다이렉트)
             .oauth2Login(oauth2 -> oauth2
-                .successHandler(jitUserProvisioningHandler) // 로그인 성공 시 우리 DB에 저장!
+                .successHandler(jitUserProvisioningHandler) // 로그인 성공 시 우리 DB에 저장 및 role 부여
+            )
+            // OAuth2 Resource Server: JWT 토큰 검증 (API 요청 시)
+            .oauth2ResourceServer(oauth2 -> oauth2
+                .jwt(jwt -> jwt
+                    .jwtAuthenticationConverter(jwtToken -> {
+                        // JWT에서 role을 추출하여 GrantedAuthority로 변환
+                        Collection<GrantedAuthority> authorities = extractAuthorities(jwtToken);
+                        return new JwtAuthenticationToken(jwtToken, authorities);
+                    })
+                    // JWT 검증은 application.yaml의 설정을 사용
+                    // issuer-uri를 통해 JWKS 엔드포인트 자동 감지
+                )
             );
         
         return http.build();
+    }
+
+    /**
+     * JWT에서 role을 추출하여 GrantedAuthority로 변환
+     * Spring Security의 @PreAuthorize에서 hasRole() 사용을 위해 필요
+     */
+    private Collection<GrantedAuthority> extractAuthorities(Jwt jwt) {
+        // 기본 scope 권한 추가
+        JwtGrantedAuthoritiesConverter defaultConverter = new JwtGrantedAuthoritiesConverter();
+        Collection<GrantedAuthority> authorities = new ArrayList<>(defaultConverter.convert(jwt));
+        
+        // JWT claims에서 role 추출
+        Map<String, Object> claims = jwt.getClaims();
+        List<IamRole> roles = extractRoles(claims);
+        
+        // IamRole을 GrantedAuthority로 변환
+        // Spring Security는 "ROLE_" prefix를 사용
+        roles.forEach(role -> {
+            authorities.add(new SimpleGrantedAuthority("ROLE_" + role.name()));
+        });
+        
+        return authorities;
+    }
+
+    /**
+     * JWT claims에서 role 목록 추출
+     * 
+     * Zitadel의 role 클레임은 다음과 같은 형태로 나타날 수 있습니다:
+     * 1. 배열 형태: ["admin", "userA"]
+     * 2. 객체 형태: {"user": {"351864415584321539": "idp.avgmax.team"}}
+     */
+    @SuppressWarnings("unchecked")
+    private List<IamRole> extractRoles(Map<String, Object> claims) {
+        List<IamRole> roles = new ArrayList<>();
+
+        // 디버깅: 모든 claims 로깅 (실제 환경에서 role 클레임 위치 확인용)
+        log.debug("JWT Claims 전체: {}", claims);
+        
+        // 1. "roles" 클레임 확인 (배열 형태)
+        Object rolesClaim = claims.get("roles");
+        if (rolesClaim instanceof List) {
+            log.debug("Found 'roles' claim (List): {}", rolesClaim);
+            ((List<?>) rolesClaim).forEach(role -> {
+                if (role instanceof String) {
+                    log.debug("Processing role from 'roles' claim: {}", role);
+                    IamRole iamRole = IamRole.fromString((String) role);
+                    if (iamRole != null) {
+                        roles.add(iamRole);
+                        log.debug("Successfully converted role: {} -> {}", role, iamRole);
+                    } else {
+                        log.warn("Failed to convert role: {}", role);
+                    }
+                }
+            });
+        }
+
+        // 2. "urn:zitadel:iam:org:project:roles" 형태의 클레임 확인
+        // 객체 형태: {"user": {"351864415584321539": "idp.avgmax.team"}}
+        log.debug("Checking all claims for role-related keys...");
+        claims.forEach((key, value) -> {
+            if (key.contains("roles") && !key.equals("roles")) {
+                log.info("Found role claim with key '{}': {}", key, value);
+                
+                // 배열 형태 처리
+                if (value instanceof List) {
+                    ((List<?>) value).forEach(role -> {
+                        if (role instanceof String) {
+                            log.debug("Processing role from '{}' claim (List): {}", key, role);
+                            IamRole iamRole = IamRole.fromString((String) role);
+                            if (iamRole != null && !roles.contains(iamRole)) {
+                                roles.add(iamRole);
+                                log.debug("Successfully converted role: {} -> {}", role, iamRole);
+                            } else if (iamRole == null) {
+                                log.warn("Failed to convert role from '{}': {}", key, role);
+                            }
+                        }
+                    });
+                }
+                // 객체 형태 처리: {"user": {"351864415584321539": "idp.avgmax.team"}}
+                else if (value instanceof Map) {
+                    Map<String, Object> roleMap = (Map<String, Object>) value;
+                    roleMap.forEach((roleName, roleValue) -> {
+                        log.debug("Processing role from '{}' claim (Object): roleName={}, roleValue={}", 
+                                key, roleName, roleValue);
+                        IamRole iamRole = IamRole.fromString(roleName);
+                        if (iamRole != null && !roles.contains(iamRole)) {
+                            roles.add(iamRole);
+                            log.debug("Successfully converted role: {} -> {}", roleName, iamRole);
+                        } else if (iamRole == null) {
+                            log.warn("Failed to convert role from '{}': roleName={}", key, roleName);
+                        }
+                    });
+                }
+            }
+        });
+
+        log.info("Extracted roles from JWT: {}", roles);
+        return roles;
     }
 }

--- a/be/src/main/resources/application-test.yaml
+++ b/be/src/main/resources/application-test.yaml
@@ -1,0 +1,48 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: 
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+  # 테스트 환경에서는 OAuth2 Client 자동 설정을 완전히 비활성화
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
+  
+  # 테스트 환경에서는 OAuth2 Resource Server 설정
+  security:
+    oauth2:
+      # OAuth2 Resource Server: 테스트용 가짜 issuer-uri (실제로는 모킹됨)
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:8080/.well-known/jwks.json
+
+  ai:
+    openai:
+      api-key: ${SPRING_AI_OPENAI_API_KEY:}
+      # Gemini API를 사용하므로 base-url도 필요
+      chat:
+        base-url: ${SPRING_AI_OPENAI_CHAT_BASE_URL:https://generativelanguage.googleapis.com/v1beta/openai/}
+        completions-path: ${SPRING_AI_OPENAI_CHAT_COMPLETIONS_PATH:/chat/completions}
+
+# 테스트용 Zitadel 설정 (실제 서버 없이 테스트)
+zitadel:
+  domain: http://localhost:9999
+  org-id: test-org-id
+  project-id: test-project-id
+  api-token: test-api-token
+
+logging:
+  level:
+    io.hlab.OpenConsole: DEBUG
+    org.springframework.web: DEBUG
+    org.springframework.security: DEBUG

--- a/be/src/main/resources/application.yaml
+++ b/be/src/main/resources/application.yaml
@@ -31,6 +31,27 @@ spring:
     ansi:
       enabled: ALWAYS
 
+
+  # security
+  security:
+    oauth2:
+      client:
+        registration:
+          zitadel: # registrationId
+            client-id: ${ZITADEL_CLIENT_ID}
+            client-secret: ${ZITADEL_CLIENT_SECRET}
+            scope:
+              - openid
+              - profile
+              - email
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/zitadel"
+            client-name: ZITADEL
+        provider:
+          zitadel:
+            issuer-uri: ${ZITADEL_ISSUER_URI}
+            user-name-attribute: sub # ID값으로 'sub'를 사용하겠다는 명시
+
   # Spring AI: Vertex AI / OpenAI(호환) 설정
   ai:
     # Vertex AI Gemini 설정 (gcloud 인증 필요)

--- a/be/src/main/resources/application.yaml
+++ b/be/src/main/resources/application.yaml
@@ -7,10 +7,10 @@ spring:
     name: OpenConsole
 
   datasource:
-    url: ${SPRING_DATASOURCE_URL}
-    username: ${SPRING_DATASOURCE_USERNAME}
+    url: ${SPRING_DATASOURCE_URL:}
+    username: ${SPRING_DATASOURCE_USERNAME:}
     password: ${SPRING_DATASOURCE_PASSWORD:}
-    driver-class-name: ${SPRING_DATASOURCE_DRIVER}
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER:}
 
   jpa:
     hibernate:
@@ -18,7 +18,7 @@ spring:
     show-sql: ${SPRING_JPA_SHOW_SQL:false}
     properties:
       hibernate:
-        dialect: ${SPRING_JPA_DIALECT}
+        dialect: ${SPRING_JPA_DIALECT:}
         format_sql: true
 
   servlet:

--- a/be/src/main/resources/application.yaml
+++ b/be/src/main/resources/application.yaml
@@ -35,6 +35,7 @@ spring:
   # security
   security:
     oauth2:
+      # OAuth2 Client: 로그인 플로우 (FE에서 리다이렉트)
       client:
         registration:
           zitadel: # registrationId
@@ -44,6 +45,13 @@ spring:
               - openid
               - profile
               - email
+              # Zitadel Project role을 scope로 요청
+              # 형식: urn:zitadel:iam:org:project:role:{roleName}
+              # 또는 Project ID를 사용한 형식 (실제 Zitadel 설정에 맞게 조정 필요)
+              - urn:zitadel:iam:org:project:role:admin
+              - urn:zitadel:iam:org:project:role:userA
+              - urn:zitadel:iam:org:project:role:userB
+              - urn:zitadel:iam:org:project:role:userC
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/login/oauth2/code/zitadel"
             client-name: ZITADEL
@@ -51,6 +59,12 @@ spring:
           zitadel:
             issuer-uri: ${ZITADEL_ISSUER_URI}
             user-name-attribute: sub # ID값으로 'sub'를 사용하겠다는 명시
+      # OAuth2 Resource Server: JWT 토큰 검증 (API 요청 시)
+      resourceserver:
+        jwt:
+          issuer-uri: ${ZITADEL_ISSUER_URI} # JWKS 엔드포인트 자동 감지
+          # JWT에서 role을 추출하기 위한 클레임 경로 설정
+          # Zitadel의 경우 role은 보통 "urn:zitadel:iam:org:project:roles" 또는 "roles" 클레임에 있음
 
   # Spring AI: Vertex AI / OpenAI(호환) 설정
   ai:
@@ -80,6 +94,13 @@ logging:
   pattern:
     console: "%clr(%-5level){green} %clr(%logger.%M\\(\\)){cyan}: %msg%n"
   level:
+    io:
+      hlab:
+        OpenConsole:
+          infrastructure:
+            security: DEBUG  # JWT role 추출 디버깅용
+            iam:
+              zitadel: DEBUG  # Zitadel API 호출 디버깅용
     org:
       springframework:
         ai:
@@ -87,6 +108,11 @@ logging:
             client:
               advisor: DEBUG
 
+zitadel:
+  domain: ${ZITADEL_DOMAIN}
+  org-id: ${ZITADEL_ORG_ID}
+  project-id: ${ZITADEL_PROJECT_ID}
+  api-token: ${ZITADEL_SERVICE_TOKEN}
 ---
 
 spring:
@@ -107,6 +133,14 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+
+  # 테스트 환경에서는 OAuth2 Resource Server를 모킹
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          # 테스트용 가짜 issuer-uri (실제로는 모킹됨)
+          issuer-uri: http://localhost:8080/.well-known/jwks.json
 
   ai:
     openai:

--- a/be/src/main/resources/application.yaml
+++ b/be/src/main/resources/application.yaml
@@ -7,10 +7,10 @@ spring:
     name: OpenConsole
 
   datasource:
-    url: ${SPRING_DATASOURCE_URL:}
-    username: ${SPRING_DATASOURCE_USERNAME:}
+    url: ${SPRING_DATASOURCE_URL:jdbc:h2:mem:defaultdb}
+    username: ${SPRING_DATASOURCE_USERNAME:sa}
     password: ${SPRING_DATASOURCE_PASSWORD:}
-    driver-class-name: ${SPRING_DATASOURCE_DRIVER:}
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER:org.h2.Driver}
 
   jpa:
     hibernate:
@@ -18,7 +18,7 @@ spring:
     show-sql: ${SPRING_JPA_SHOW_SQL:false}
     properties:
       hibernate:
-        dialect: ${SPRING_JPA_DIALECT:}
+        dialect: ${SPRING_JPA_DIALECT:org.hibernate.dialect.H2Dialect}
         format_sql: true
 
   servlet:
@@ -39,8 +39,8 @@ spring:
       client:
         registration:
           zitadel: # registrationId
-            client-id: ${ZITADEL_CLIENT_ID}
-            client-secret: ${ZITADEL_CLIENT_SECRET}
+            client-id: ${ZITADEL_CLIENT_ID:}
+            client-secret: ${ZITADEL_CLIENT_SECRET:}
             scope:
               - openid
               - profile
@@ -57,12 +57,12 @@ spring:
             client-name: ZITADEL
         provider:
           zitadel:
-            issuer-uri: ${ZITADEL_ISSUER_URI}
+            issuer-uri: ${ZITADEL_ISSUER_URI:}
             user-name-attribute: sub # ID값으로 'sub'를 사용하겠다는 명시
       # OAuth2 Resource Server: JWT 토큰 검증 (API 요청 시)
       resourceserver:
         jwt:
-          issuer-uri: ${ZITADEL_ISSUER_URI} # JWKS 엔드포인트 자동 감지
+          issuer-uri: ${ZITADEL_ISSUER_URI:} # JWKS 엔드포인트 자동 감지
           # JWT에서 role을 추출하기 위한 클레임 경로 설정
           # Zitadel의 경우 role은 보통 "urn:zitadel:iam:org:project:roles" 또는 "roles" 클레임에 있음
 
@@ -111,59 +111,7 @@ logging:
 zitadel:
   # domain은 프로토콜 포함 가능 (http:// 또는 https://) 또는 프로토콜 없이 도메인만
   # 프로토콜이 없으면 자동으로 https://가 추가됨
-  domain: ${ZITADEL_DOMAIN}
-  org-id: ${ZITADEL_ORG_ID}
-  project-id: ${ZITADEL_PROJECT_ID}
-  api-token: ${ZITADEL_SERVICE_TOKEN}
----
-
-spring:
-  config:
-    activate:
-      on-profile: test
-
-  datasource:
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL
-    driver-class-name: org.h2.Driver
-    username: sa
-    password: 
-
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    show-sql: false
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
-
-  # 테스트 환경에서는 OAuth2 Client/Resource Server 설정
-  security:
-    oauth2:
-      # OAuth2 Client: 테스트 환경에서는 자동 설정을 비활성화 (실제 로그인 플로우 테스트 불필요)
-      client:
-        registration: {}  # 빈 객체로 설정하여 OAuth2 Client 자동 설정 비활성화
-      # OAuth2 Resource Server: 테스트용 가짜 issuer-uri (실제로는 모킹됨)
-      resourceserver:
-        jwt:
-          issuer-uri: http://localhost:8080/.well-known/jwks.json
-
-  ai:
-    openai:
-      api-key: ${SPRING_AI_OPENAI_API_KEY:}
-      # Gemini API를 사용하므로 base-url도 필요
-      chat:
-        base-url: ${SPRING_AI_OPENAI_CHAT_BASE_URL:https://generativelanguage.googleapis.com/v1beta/openai/}
-        completions-path: ${SPRING_AI_OPENAI_CHAT_COMPLETIONS_PATH:/chat/completions}
-
-# 테스트용 Zitadel 설정 (실제 서버 없이 테스트)
-zitadel:
-  domain: http://localhost:9999
-  org-id: test-org-id
-  project-id: test-project-id
-  api-token: test-api-token
-
-logging:
-  level:
-    io.hlab.OpenConsole: DEBUG
-    org.springframework.web: DEBUG
-    org.springframework.security: DEBUG
+  domain: ${ZITADEL_DOMAIN:}
+  org-id: ${ZITADEL_ORG_ID:}
+  project-id: ${ZITADEL_PROJECT_ID:}
+  api-token: ${ZITADEL_SERVICE_TOKEN:}

--- a/be/src/main/resources/application.yaml
+++ b/be/src/main/resources/application.yaml
@@ -109,6 +109,8 @@ logging:
               advisor: DEBUG
 
 zitadel:
+  # domain은 프로토콜 포함 가능 (http:// 또는 https://) 또는 프로토콜 없이 도메인만
+  # 프로토콜이 없으면 자동으로 https://가 추가됨
   domain: ${ZITADEL_DOMAIN}
   org-id: ${ZITADEL_ORG_ID}
   project-id: ${ZITADEL_PROJECT_ID}

--- a/be/src/main/resources/application.yaml
+++ b/be/src/main/resources/application.yaml
@@ -136,12 +136,15 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
 
-  # 테스트 환경에서는 OAuth2 Resource Server를 모킹
+  # 테스트 환경에서는 OAuth2 Client/Resource Server 설정
   security:
     oauth2:
+      # OAuth2 Client: 테스트 환경에서는 자동 설정을 비활성화 (실제 로그인 플로우 테스트 불필요)
+      client:
+        registration: {}  # 빈 객체로 설정하여 OAuth2 Client 자동 설정 비활성화
+      # OAuth2 Resource Server: 테스트용 가짜 issuer-uri (실제로는 모킹됨)
       resourceserver:
         jwt:
-          # 테스트용 가짜 issuer-uri (실제로는 모킹됨)
           issuer-uri: http://localhost:8080/.well-known/jwks.json
 
   ai:

--- a/be/src/main/resources/application.yaml
+++ b/be/src/main/resources/application.yaml
@@ -149,3 +149,16 @@ spring:
       chat:
         base-url: ${SPRING_AI_OPENAI_CHAT_BASE_URL:https://generativelanguage.googleapis.com/v1beta/openai/}
         completions-path: ${SPRING_AI_OPENAI_CHAT_COMPLETIONS_PATH:/chat/completions}
+
+# 테스트용 Zitadel 설정 (실제 서버 없이 테스트)
+zitadel:
+  domain: http://localhost:9999
+  org-id: test-org-id
+  project-id: test-project-id
+  api-token: test-api-token
+
+logging:
+  level:
+    io.hlab.OpenConsole: DEBUG
+    org.springframework.web: DEBUG
+    org.springframework.security: DEBUG

--- a/be/src/test/java/io/hlab/OpenConsole/OpenConsoleApplicationTests.java
+++ b/be/src/test/java/io/hlab/OpenConsole/OpenConsoleApplicationTests.java
@@ -1,7 +1,6 @@
 package io.hlab.OpenConsole;
 
-import io.hlab.OpenConsole.infrastructure.iam.zitadel.client.ZitadelAuthExecutor;
-import io.hlab.OpenConsole.infrastructure.iam.zitadel.client.ZitadelUserExecutor;
+import io.hlab.OpenConsole.infrastructure.iam.IamClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -10,18 +9,15 @@ import org.springframework.test.context.ActiveProfiles;
 /**
  * Spring Boot 애플리케이션 컨텍스트 로드 테스트
  * 
- * <p>Zitadel 관련 Executor는 모킹하여 실제 API 호출을 방지합니다.
- * 테스트 환경에서는 실제 Zitadel 서버가 없으므로 모킹이 필요합니다.
+ * <p>테스트 환경에서는 실제 Zitadel 서버가 없으므로 IamClient를 모킹합니다.
+ * test 프로필에서는 ZitadelClient가 생성되지 않으므로 IamClient를 @MockBean으로 모킹합니다.
  */
 @SpringBootTest
 @ActiveProfiles("test")
 class OpenConsoleApplicationTests {
 
     @MockBean
-    private ZitadelAuthExecutor zitadelAuthExecutor;
-
-    @MockBean
-    private ZitadelUserExecutor zitadelUserExecutor;
+    private IamClient iamClient;
 
 	@Test
 	void contextLoads() {

--- a/be/src/test/java/io/hlab/OpenConsole/OpenConsoleApplicationTests.java
+++ b/be/src/test/java/io/hlab/OpenConsole/OpenConsoleApplicationTests.java
@@ -1,12 +1,27 @@
 package io.hlab.OpenConsole;
 
+import io.hlab.OpenConsole.infrastructure.iam.zitadel.client.ZitadelAuthExecutor;
+import io.hlab.OpenConsole.infrastructure.iam.zitadel.client.ZitadelUserExecutor;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
+/**
+ * Spring Boot 애플리케이션 컨텍스트 로드 테스트
+ * 
+ * <p>Zitadel 관련 Executor는 모킹하여 실제 API 호출을 방지합니다.
+ * 테스트 환경에서는 실제 Zitadel 서버가 없으므로 모킹이 필요합니다.
+ */
 @SpringBootTest
 @ActiveProfiles("test")
 class OpenConsoleApplicationTests {
+
+    @MockBean
+    private ZitadelAuthExecutor zitadelAuthExecutor;
+
+    @MockBean
+    private ZitadelUserExecutor zitadelUserExecutor;
 
 	@Test
 	void contextLoads() {

--- a/be/src/test/java/io/hlab/OpenConsole/api/role/RoleControllerIntegrationTest.java
+++ b/be/src/test/java/io/hlab/OpenConsole/api/role/RoleControllerIntegrationTest.java
@@ -54,6 +54,9 @@ class RoleControllerIntegrationTest {
     @MockBean
     private io.hlab.OpenConsole.infrastructure.security.JwtUtils jwtUtils;
 
+    @MockBean
+    private io.hlab.OpenConsole.infrastructure.iam.IamClient iamClient;
+
     private static final String TEST_EMAIL = "test@example.com";
     private Jwt jwtWithAdminRole;
 

--- a/be/src/test/java/io/hlab/OpenConsole/api/role/RoleControllerIntegrationTest.java
+++ b/be/src/test/java/io/hlab/OpenConsole/api/role/RoleControllerIntegrationTest.java
@@ -1,0 +1,264 @@
+package io.hlab.OpenConsole.api.role;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hlab.OpenConsole.api.role.dto.RoleAssignRequest;
+import io.hlab.OpenConsole.application.role.RoleService;
+import io.hlab.OpenConsole.infrastructure.iam.IamException;
+import io.hlab.OpenConsole.infrastructure.iam.IamRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * RoleController 통합 테스트
+ * MockMvc를 사용하여 HTTP 요청/응답을 테스트
+ * 
+ * @SpringBootTest 사용 이유:
+ * - 전체 애플리케이션 컨텍스트 로드로 Security 설정이 완전히 적용됨
+ * - JWT 인증/인가 필터가 정상적으로 작동하여 통합 테스트에 적합
+ */
+@SpringBootTest
+@AutoConfigureMockMvc  // Security 필터 자동 적용
+@ActiveProfiles("test")
+@DisplayName("RoleController 통합 테스트")
+class RoleControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private RoleService roleService;
+
+    @MockBean
+    private io.hlab.OpenConsole.infrastructure.security.JwtUtils jwtUtils;
+
+    private static final String TEST_EMAIL = "test@example.com";
+    private Jwt jwtWithAdminRole;
+
+    @BeforeEach
+    void setUp() {
+        // ADMIN role을 가진 JWT 토큰 생성
+        jwtWithAdminRole = Jwt.withTokenValue("test-token")
+                .header("alg", "RS256")
+                .claim("sub", "test-user-id")
+                .claim("email", "admin@test.com")
+                .claim("roles", List.of("admin"))
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(3600))
+                .build();
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한 사용자가 Role 부여 성공")
+    void assignRole_withAdminRole_success() throws Exception {
+        // Given
+        RoleAssignRequest request = new RoleAssignRequest();
+        request.setEmail(TEST_EMAIL);
+        request.setRoles(List.of(IamRole.USER_A));
+
+        doNothing().when(roleService).assignRoles(eq(TEST_EMAIL), any());
+
+        // When & Then
+        mockMvc.perform(post("/roles")
+                        .with(jwt().jwt(jwtWithAdminRole)
+                                .authorities(new SimpleGrantedAuthority("ROLE_ADMIN")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("Role이 부여되었습니다."))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(roleService, times(1)).assignRoles(eq(TEST_EMAIL), any());
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한 없는 사용자는 Role 부여 실패")
+    void assignRole_withoutAdminRole_forbidden() throws Exception {
+        // Given
+        RoleAssignRequest request = new RoleAssignRequest();
+        request.setEmail(TEST_EMAIL);
+        request.setRoles(List.of(IamRole.USER_A));
+
+        Jwt jwtWithoutAdmin = Jwt.withTokenValue("test-token")
+                .header("alg", "RS256")
+                .claim("sub", "test-user-id")
+                .claim("email", "user@test.com")
+                .claim("roles", List.of("userA"))
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(3600))
+                .build();
+
+        // When & Then
+        mockMvc.perform(post("/roles")
+                        .with(jwt().jwt(jwtWithoutAdmin)
+                                .authorities(new SimpleGrantedAuthority("ROLE_USER_A")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+
+        verify(roleService, never()).assignRoles(any(), any());
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자는 Role 부여 실패")
+    void assignRole_unauthenticated_unauthorized() throws Exception {
+        // Given
+        RoleAssignRequest request = new RoleAssignRequest();
+        request.setEmail(TEST_EMAIL);
+        request.setRoles(List.of(IamRole.USER_A));
+
+        // When & Then
+        mockMvc.perform(post("/roles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+
+        verify(roleService, never()).assignRoles(any(), any());
+    }
+
+    @Test
+    @DisplayName("잘못된 요청 형식 - Email 누락")
+    void assignRole_invalidRequest_emailMissing_badRequest() throws Exception {
+        // Given
+        RoleAssignRequest request = new RoleAssignRequest();
+        request.setRoles(List.of(IamRole.USER_A));
+        // email 필드 누락
+
+        // When & Then
+        mockMvc.perform(post("/roles")
+                        .with(jwt().jwt(jwtWithAdminRole)
+                                .authorities(new SimpleGrantedAuthority("ROLE_ADMIN")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+        verify(roleService, never()).assignRoles(any(), any());
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한 사용자가 Role 제거 성공")
+    void removeRole_withAdminRole_success() throws Exception {
+        // Given
+        doNothing().when(roleService).removeRole(eq(TEST_EMAIL), eq(IamRole.USER_A));
+
+        // When & Then
+        mockMvc.perform(delete("/roles")
+                        .with(jwt().jwt(jwtWithAdminRole)
+                                .authorities(new SimpleGrantedAuthority("ROLE_ADMIN")))
+                        .param("email", TEST_EMAIL)
+                        .param("role", "USER_A"))
+                .andExpect(status().isOk())  // ApiResponse를 반환하므로 200 OK
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("Role이 제거되었습니다."))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(roleService, times(1)).removeRole(eq(TEST_EMAIL), eq(IamRole.USER_A));
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한 사용자가 Role 조회 성공")
+    void getUserRoles_withAdminRole_success() throws Exception {
+        // Given
+        List<IamRole> expectedRoles = List.of(IamRole.USER_A, IamRole.USER_B);
+        when(roleService.getUserRoles(TEST_EMAIL)).thenReturn(expectedRoles);
+
+        // When & Then
+        mockMvc.perform(get("/roles")
+                        .with(jwt().jwt(jwtWithAdminRole)
+                                .authorities(new SimpleGrantedAuthority("ROLE_ADMIN")))
+                        .param("email", TEST_EMAIL))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.email").value(TEST_EMAIL))
+                .andExpect(jsonPath("$.data.roles[0]").value("USER_A"))
+                .andExpect(jsonPath("$.data.roles[1]").value("USER_B"));
+
+        verify(roleService, times(1)).getUserRoles(TEST_EMAIL);
+    }
+
+    @Test
+    @DisplayName("IAM 에러 발생 시 적절한 에러 응답")
+    void assignRole_iamException_errorResponse() throws Exception {
+        // Given
+        RoleAssignRequest request = new RoleAssignRequest();
+        request.setEmail(TEST_EMAIL);
+        request.setRoles(List.of(IamRole.USER_A));
+
+        doThrow(new IamException("IAM 처리 중 오류가 발생했습니다."))
+                .when(roleService).assignRoles(eq(TEST_EMAIL), any());
+
+        // When & Then
+        mockMvc.perform(post("/roles")
+                        .with(jwt().jwt(jwtWithAdminRole)
+                                .authorities(new SimpleGrantedAuthority("ROLE_ADMIN")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value("IAM_ERROR"))
+                .andExpect(jsonPath("$.message").value("IAM 처리 중 오류가 발생했습니다."));
+
+        verify(roleService, times(1)).assignRoles(eq(TEST_EMAIL), any());
+    }
+
+    @Test
+    @DisplayName("현재 사용자 Role 조회 - 인증된 사용자")
+    void getMyRoles_authenticatedUser_success() throws Exception {
+        // Given
+        String currentEmail = "current@example.com";
+        List<IamRole> expectedRoles = List.of(IamRole.USER_A);
+        
+        when(jwtUtils.getCurrentUserEmail()).thenReturn(currentEmail);
+        when(roleService.getCurrentUserRoles()).thenReturn(expectedRoles);
+
+        // When & Then
+        mockMvc.perform(get("/roles/me")
+                        .with(jwt().jwt(jwtWithAdminRole)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.email").value(currentEmail))
+                .andExpect(jsonPath("$.data.roles[0]").value("USER_A"));
+
+        verify(jwtUtils, times(1)).getCurrentUserEmail();
+        verify(roleService, times(1)).getCurrentUserRoles();
+    }
+
+    @Test
+    @DisplayName("현재 사용자 Role 조회 - Email을 가져올 수 없는 경우")
+    void getMyRoles_emailNotFound_errorResponse() throws Exception {
+        // Given
+        when(jwtUtils.getCurrentUserEmail()).thenReturn(null);
+
+        // When & Then
+        mockMvc.perform(get("/roles/me")
+                        .with(jwt().jwt(jwtWithAdminRole)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                .andExpect(jsonPath("$.message").value("사용자 정보를 확인할 수 없습니다."));
+
+        verify(jwtUtils, times(1)).getCurrentUserEmail();
+        verify(roleService, never()).getCurrentUserRoles();
+    }
+}

--- a/be/src/test/java/io/hlab/OpenConsole/api/user/UserControllerSecurityTest.java
+++ b/be/src/test/java/io/hlab/OpenConsole/api/user/UserControllerSecurityTest.java
@@ -1,0 +1,147 @@
+package io.hlab.OpenConsole.api.user;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hlab.OpenConsole.api.user.dto.UserCreateRequest;
+import io.hlab.OpenConsole.domain.user.User;
+import io.hlab.OpenConsole.domain.user.UserRepository;
+import io.hlab.OpenConsole.infrastructure.iam.IamRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * UserController의 Security 테스트
+ * JWT 토큰 기반 인증 및 Role 기반 권한 체크 테스트
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class UserControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Jwt jwtWithAdminRole;
+    private Jwt jwtWithUserARole;
+
+    @BeforeEach
+    void setUp() {
+        // ADMIN role을 가진 JWT 토큰 생성
+        jwtWithAdminRole = Jwt.withTokenValue("test-token")
+                .header("alg", "RS256")
+                .claim("sub", "test-user-id")
+                .claim("email", "admin@test.com")
+                .claim("roles", List.of("admin"))
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(3600))
+                .build();
+
+        // USER_A role을 가진 JWT 토큰 생성
+        jwtWithUserARole = Jwt.withTokenValue("test-token")
+                .header("alg", "RS256")
+                .claim("sub", "test-user-id")
+                .claim("email", "usera@test.com")
+                .claim("roles", List.of("userA"))
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(3600))
+                .build();
+    }
+
+    @Test
+    @Disabled("실제 OAuth2 로그인 플로우가 필요하므로 테스트 환경에서는 동작하지 않음. Swagger UI나 Postman으로 실제 환경에서 테스트하세요.")
+    @DisplayName("인증된 사용자는 자신의 정보를 조회할 수 있다")
+    void getMyInfo_authenticatedUser_success() throws Exception {
+        // Given: DB에 사용자 생성 (JWT의 email과 일치해야 함)
+        User user = User.create("usera@test.com", "Test User");
+        userRepository.save(user);
+
+        // When & Then: JWT 토큰과 함께 요청
+        // 주의: getMyInfo는 OidcUser를 사용하므로 JWT 토큰만으로는 동작하지 않을 수 있음
+        // 실제로는 OAuth2 로그인 플로우를 거쳐야 함
+        mockMvc.perform(get("/users/api/me")
+                        .with(jwt().jwt(jwtWithUserARole)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자는 API에 접근할 수 없다")
+    void getMyInfo_unauthenticatedUser_forbidden() throws Exception {
+        mockMvc.perform(get("/users/api/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("ADMIN role을 가진 사용자는 ADMIN 전용 API에 접근할 수 있다")
+    void adminOnly_withAdminRole_success() throws Exception {
+        mockMvc.perform(get("/users/example/admin-only")
+                        .with(jwt().jwt(jwtWithAdminRole)
+                                .authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("ADMIN role이 없는 사용자는 ADMIN 전용 API에 접근할 수 없다")
+    void adminOnly_withoutAdminRole_forbidden() throws Exception {
+        mockMvc.perform(get("/users/example/admin-only")
+                        .with(jwt().jwt(jwtWithUserARole)
+                                .authorities(new SimpleGrantedAuthority("ROLE_USER_A"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("USER_A role을 가진 사용자는 USER_A 접근 가능 API에 접근할 수 있다")
+    void adminOrUserA_withUserARole_success() throws Exception {
+        mockMvc.perform(get("/users/example/admin-or-user-a")
+                        .with(jwt().jwt(jwtWithUserARole)
+                                .authorities(new SimpleGrantedAuthority("ROLE_USER_A"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("인증된 사용자는 사용자 생성 API를 호출할 수 있다")
+    void createUser_authenticatedUser_success() throws Exception {
+        // UserCreateRequest는 생성자나 빌더 패턴을 사용할 수 있음
+        // 실제 구조에 맞게 수정 필요
+        String requestBody = """
+            {
+                "email": "newuser@test.com",
+                "name": "New User"
+            }
+            """;
+
+        mockMvc.perform(post("/users")
+                        .with(jwt().jwt(jwtWithUserARole))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value("SUCCESS"));
+    }
+}
+

--- a/be/src/test/java/io/hlab/OpenConsole/api/user/UserControllerSecurityTest.java
+++ b/be/src/test/java/io/hlab/OpenConsole/api/user/UserControllerSecurityTest.java
@@ -4,9 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.hlab.OpenConsole.api.user.dto.UserCreateRequest;
 import io.hlab.OpenConsole.domain.user.User;
 import io.hlab.OpenConsole.domain.user.UserRepository;
+import io.hlab.OpenConsole.infrastructure.iam.IamClient;
 import io.hlab.OpenConsole.infrastructure.iam.IamRole;
-import io.hlab.OpenConsole.infrastructure.iam.zitadel.client.ZitadelAuthExecutor;
-import io.hlab.OpenConsole.infrastructure.iam.zitadel.client.ZitadelUserExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Disabled;
@@ -54,10 +53,7 @@ class UserControllerSecurityTest {
     private UserRepository userRepository;
 
     @MockBean
-    private ZitadelAuthExecutor zitadelAuthExecutor;
-
-    @MockBean
-    private ZitadelUserExecutor zitadelUserExecutor;
+    private IamClient iamClient;
 
     private Jwt jwtWithAdminRole;
     private Jwt jwtWithUserARole;

--- a/be/src/test/java/io/hlab/OpenConsole/api/user/UserControllerSecurityTest.java
+++ b/be/src/test/java/io/hlab/OpenConsole/api/user/UserControllerSecurityTest.java
@@ -5,6 +5,8 @@ import io.hlab.OpenConsole.api.user.dto.UserCreateRequest;
 import io.hlab.OpenConsole.domain.user.User;
 import io.hlab.OpenConsole.domain.user.UserRepository;
 import io.hlab.OpenConsole.infrastructure.iam.IamRole;
+import io.hlab.OpenConsole.infrastructure.iam.zitadel.client.ZitadelAuthExecutor;
+import io.hlab.OpenConsole.infrastructure.iam.zitadel.client.ZitadelUserExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Disabled;
@@ -12,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -31,6 +34,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * UserController의 Security 테스트
  * JWT 토큰 기반 인증 및 Role 기반 권한 체크 테스트
+ * 
+ * <p>Zitadel 관련 Executor는 모킹하여 실제 API 호출을 방지합니다.
+ * 테스트 환경에서는 실제 Zitadel 서버가 없으므로 모킹이 필요합니다.
  */
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -46,6 +52,12 @@ class UserControllerSecurityTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @MockBean
+    private ZitadelAuthExecutor zitadelAuthExecutor;
+
+    @MockBean
+    private ZitadelUserExecutor zitadelUserExecutor;
 
     private Jwt jwtWithAdminRole;
     private Jwt jwtWithUserARole;

--- a/be/src/test/java/io/hlab/OpenConsole/application/role/RoleServiceTest.java
+++ b/be/src/test/java/io/hlab/OpenConsole/application/role/RoleServiceTest.java
@@ -1,0 +1,142 @@
+package io.hlab.OpenConsole.application.role;
+
+import io.hlab.OpenConsole.infrastructure.iam.IamClient;
+import io.hlab.OpenConsole.infrastructure.iam.IamException;
+import io.hlab.OpenConsole.infrastructure.iam.IamRole;
+import io.hlab.OpenConsole.infrastructure.security.JwtUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * RoleService 통합 테스트
+ * IamClient를 Mock하여 RoleService의 비즈니스 로직을 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RoleService 통합 테스트")
+class RoleServiceTest {
+
+    @Mock
+    private IamClient iamClient;
+
+    @Mock
+    private JwtUtils jwtUtils;
+
+    @InjectMocks
+    private RoleService roleService;
+
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_SUBJECT = "test-subject-id";
+
+    @BeforeEach
+    void setUp() {
+        // 기본 설정: Email → Subject 변환
+        when(iamClient.getUserSubjectByEmail(TEST_EMAIL)).thenReturn(TEST_SUBJECT);
+    }
+
+    @Test
+    @DisplayName("단일 Role 부여 성공")
+    void assignRole_singleRole_success() throws IamException {
+        // Given
+        IamRole role = IamRole.USER_A;
+
+        // When
+        roleService.assignRole(TEST_EMAIL, role);
+
+        // Then
+        verify(iamClient, times(1)).getUserSubjectByEmail(TEST_EMAIL);
+        verify(iamClient, times(1)).assignRoles(eq(TEST_SUBJECT), eq(List.of(role)));
+    }
+
+    @Test
+    @DisplayName("여러 Role 부여 성공")
+    void assignRoles_multipleRoles_success() throws IamException {
+        // Given
+        List<IamRole> roles = List.of(IamRole.ADMIN, IamRole.USER_A, IamRole.USER_B);
+
+        // When
+        roleService.assignRoles(TEST_EMAIL, roles);
+
+        // Then
+        verify(iamClient, times(1)).getUserSubjectByEmail(TEST_EMAIL);
+        verify(iamClient, times(1)).assignRoles(eq(TEST_SUBJECT), eq(roles));
+    }
+
+    @Test
+    @DisplayName("Role 제거 성공")
+    void removeRole_success() throws IamException {
+        // Given
+        IamRole role = IamRole.USER_A;
+
+        // When
+        roleService.removeRole(TEST_EMAIL, role);
+
+        // Then
+        verify(iamClient, times(1)).getUserSubjectByEmail(TEST_EMAIL);
+        verify(iamClient, times(1)).removeRole(eq(TEST_SUBJECT), eq(role));
+    }
+
+    @Test
+    @DisplayName("Role 조회 성공")
+    void getUserRoles_success() throws IamException {
+        // Given
+        List<IamRole> expectedRoles = List.of(IamRole.ADMIN, IamRole.USER_A);
+        when(iamClient.getUserRoles(TEST_SUBJECT)).thenReturn(expectedRoles);
+
+        // When
+        List<IamRole> actualRoles = roleService.getUserRoles(TEST_EMAIL);
+
+        // Then
+        assertThat(actualRoles).isEqualTo(expectedRoles);
+        verify(iamClient, times(1)).getUserSubjectByEmail(TEST_EMAIL);
+        verify(iamClient, times(1)).getUserRoles(TEST_SUBJECT);
+    }
+
+    @Test
+    @DisplayName("사용자 존재하지 않을 때 Role 부여 실패")
+    void assignRole_userNotFound_throwsException() throws IamException {
+        // Given
+        when(iamClient.getUserSubjectByEmail(TEST_EMAIL))
+                .thenThrow(new IamException("사용자를 찾을 수 없습니다: email=" + TEST_EMAIL));
+
+        // When & Then
+        assertThatThrownBy(() -> roleService.assignRole(TEST_EMAIL, IamRole.USER_A))
+                .isInstanceOf(IamException.class)
+                .hasMessageContaining("사용자를 찾을 수 없습니다");
+
+        verify(iamClient, times(1)).getUserSubjectByEmail(TEST_EMAIL);
+        verify(iamClient, never()).assignRoles(any(), any());
+    }
+
+    @Test
+    @DisplayName("IAM API 호출 실패 시 Role 부여 실패")
+    void assignRole_iamApiFailure_throwsException() throws IamException {
+        // Given
+        doThrow(new IamException("Role 부여에 실패했습니다."))
+                .when(iamClient).assignRoles(eq(TEST_SUBJECT), any());
+
+        // When & Then
+        assertThatThrownBy(() -> roleService.assignRoles(TEST_EMAIL, List.of(IamRole.USER_A)))
+                .isInstanceOf(IamException.class)
+                .hasMessageContaining("Role 부여에 실패했습니다");
+
+        verify(iamClient, times(1)).getUserSubjectByEmail(TEST_EMAIL);
+        verify(iamClient, times(1)).assignRoles(any(), any());
+    }
+
+    // Note: getCurrentUserRoles()는 SecurityContext에서 JWT를 읽는 구현이므로
+    // 단위 테스트는 어렵고, 통합 테스트(RoleControllerIntegrationTest)에서 검증합니다.
+    // 여기서는 단위 테스트를 제외하고 통합 테스트에서만 검증합니다.
+}


### PR DESCRIPTION
## 📝 Summary

- Zitadel Management API를 v2 Protobuf 스펙에 맞게 리팩토링하고, 코드 구조를 개선하며, 통합 테스트를 추가했습니다.(자세한 내용은 아래 참고)

---

## 🔗 Related Issue
Closes #15 

---

## 📦 Changes

- 1. Zitadel API v2 마이그레이션
- 2. 아키텍처 개선
- 3. Exception Handling 개선
- 4. 코드 품질 개선
- 5. 통합 테스트 추가

---

## 🧪 Test Plan

- [ ] 로컬에서 빌드 확인함
- [ ] 기능 동작 확인함
- [ ] Lint 통과함

---

## 📸 Screenshots (선택)

---

## 🔍 Checklist
- [ ] PR 제목 컨벤션 준수 (feat/fix/chore 등)
- [ ] 불필요한 변경 없음
- [ ] 관련 없는 commit 없음
- [ ] 리뷰어가 이해하기 쉬운 상태인지 확인함

---

## 주요 변경사항
### 1. Zitadel API v2 마이그레이션

#### 변경 전
- Zitadel API v1/v2 혼용 (추정)
- DTO가 분산되어 있음
- 직접적인 WebClient 호출

#### 변경 후
- **Zitadel API v2 Protobuf 스펙 준수**
- **DTO를 Record로 통합 및 재구성**
  - `ZitadelAuthorizationDto`: Authorization API 관련 모든 DTO 통합
  - `ZitadelUserDto`: User API 관련 모든 DTO 통합
- **Facade 패턴 적용**
  - `ZitadelClient`: Facade 역할 (비즈니스 로직)
  - `ZitadelAuthExecutor`: Authorization API 전용 Executor
  - `ZitadelUserExecutor`: User API 전용 Executor

### 2. 아키텍처 개선

#### 디렉토리 구조
```
infrastructure/iam/zitadel/
├── dto/
│   ├── ZitadelAuthorizationDto.java  (모든 Authorization DTO 통합)
│   └── ZitadelUserDto.java           (모든 User DTO 통합)
├── client/
│   ├── ZitadelAuthExecutor.java      (Authorization API 호출)
│   └── ZitadelUserExecutor.java      (User API 호출)
└── ZitadelClient.java                (Facade - 비즈니스 로직)
```

#### 설계 원칙
- **단일 책임 원칙 (SRP)**: 각 클래스가 명확한 책임을 가짐
- **의존성 역전 원칙 (DIP)**: Application Layer가 인터페이스에 의존
- **Facade 패턴**: 복잡한 하위 시스템을 단순한 인터페이스로 제공

### 3. Exception Handling 개선

#### 변경 전
- 각 레이어에서 개별적으로 예외 처리
- 중복된 try-catch 블록
- 일관성 없는 에러 응답

#### 변경 후
- **중앙화된 예외 처리**: `GlobalExceptionHandler`에서 통합 처리
- **ErrorCode enum**: 에러 코드, 메시지, HTTP 상태 코드 통합 관리
- **예외 전파**: Infrastructure → Application → API 레이어로 자연스럽게 전파
- **IamException 처리**: IAM 관련 예외를 일관된 형식으로 응답

### 4. 코드 품질 개선

#### Optional 사용
- `findAuthorizationId()`: `Optional<String>` 반환으로 null 안전성 확보
- 호출하는 쪽에서 검증 책임을 가지도록 개선

#### 중복 코드 제거
- `getCurrentRoleKeys()`: 헬퍼 메서드로 추출하여 재사용

#### Role 부여 로직 개선
- **Add 전략**: 기존 role을 유지하면서 새로운 role 추가
- 409 Conflict 처리: 기존 grant가 있으면 병합하여 업데이트

### 5. 통합 테스트 추가

#### 테스트 구조
- **RoleServiceTest**: Application Layer 테스트 (Mock IamClient)
- **RoleControllerIntegrationTest**: API Layer 통합 테스트 (MockMvc)

#### 테스트 커버리지
- ✅ Role 부여/제거/조회 기능
- ✅ 권한 체크 (ADMIN 권한 필요)
- ✅ 에러 처리
- ✅ 입력 검증
- ✅ 인증/인가 검증

#### 테스트 결과
- **총 테스트**: 16개
- **통과**: 16개 (100%)
- **실패**: 0개

#### 테스트 전략
- `@SpringBootTest` 사용: 전체 애플리케이션 컨텍스트 로드로 Security 설정 완전 적용
- MockMvc로 HTTP 요청/응답 테스트
- Mockito로 Service 계층 모킹
