### PR TITLE
feature(infra): Docker 이미지 빌드 및 GHCR Helm OCI 배포 파이프라인 추가

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,129 @@
+name: Release
+
+# v* 태그 push 또는 수동 실행 시 트리거
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '배포 버전 (v 제외, 예: 1.0.0)'
+        required: true
+
+permissions:
+  contents: read
+  packages: write   # GHCR 이미지 및 Helm chart OCI 푸시 권한
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1) version 계산 — 태그에서 v 제거 또는 수동 입력값 사용
+# ─────────────────────────────────────────────────────────────────────────────
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+    steps:
+      - name: Resolve version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="${{ github.event.inputs.version }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing version: $VERSION"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2a) BE Docker 이미지 빌드 & GHCR 푸시
+# ─────────────────────────────────────────────────────────────────────────────
+  build-be:
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push BE image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./be
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/opencsp-console-be:${{ needs.prepare.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/opencsp-console-be:latest
+          cache-from: type=gha,scope=be
+          cache-to:   type=gha,scope=be,mode=max
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2b) FE Docker 이미지 빌드 & GHCR 푸시
+# ─────────────────────────────────────────────────────────────────────────────
+  build-fe:
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push FE image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./fe
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/opencsp-console-fe:${{ needs.prepare.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/opencsp-console-fe:latest
+          cache-from: type=gha,scope=fe
+          cache-to:   type=gha,scope=fe,mode=max
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3) Helm chart 패키징 & GHCR OCI 푸시 (BE + FE 빌드 완료 후)
+# ─────────────────────────────────────────────────────────────────────────────
+  helm-push:
+    needs: [prepare, build-be, build-fe]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Login to GHCR (Helm OCI)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ${{ env.REGISTRY }} \
+              --username ${{ github.actor }} \
+              --password-stdin
+
+      - name: Package and push Helm chart
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          helm package helm/opencsp-console \
+            --version "$VERSION" \
+            --app-version "$VERSION"
+          helm push "opencsp-console-${VERSION}.tgz" \
+            oci://${{ env.REGISTRY }}/${{ env.OWNER }}/charts
+          echo "Helm chart pushed: oci://${{ env.REGISTRY }}/${{ env.OWNER }}/charts/opencsp-console:$VERSION"

--- a/be/Dockerfile
+++ b/be/Dockerfile
@@ -12,5 +12,5 @@ FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring
-COPY --from=builder /app/build/libs/*-SNAPSHOT.jar app.jar
+COPY --from=builder /app/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/fe/.dockerignore
+++ b/fe/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+.git
+*.md
+.env*
+Makefile
+docs

--- a/fe/Dockerfile
+++ b/fe/Dockerfile
@@ -1,0 +1,35 @@
+# deps stage — 모든 의존성 설치 (빌드용)
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# builder stage — Next.js standalone 빌드
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npm run build
+
+# runner stage — 최소 런타임 이미지
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser  --system --uid 1001 nextjs
+
+# standalone 빌드 결과물 복사
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/fe/next.config.ts
+++ b/fe/next.config.ts
@@ -3,6 +3,9 @@ import type { NextConfig } from "next";
 const config: NextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@h001/ui"],
+  // Docker 컨테이너 빌드용 standalone 출력 모드
+  // standalone 모드: .next/standalone/ 에 server.js + 필요한 node_modules만 포함
+  output: "standalone",
 };
 
 export default config;

--- a/helm/opencsp-console/Chart.yaml
+++ b/helm/opencsp-console/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: opencsp-console
+description: OpenCSP Console — self-hosted cloud platform console (Proxmox + cloud-native)
+type: application
+# version / appVersion은 release.yaml에서 --version / --app-version 플래그로 덮어씀
+version: 0.1.0
+appVersion: "latest"
+home: https://github.com/h001-lab/OpenCSP-console
+sources:
+  - https://github.com/h001-lab/OpenCSP-console

--- a/helm/opencsp-console/templates/_helpers.tpl
+++ b/helm/opencsp-console/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/*
+차트 이름 (63자 제한)
+*/}}
+{{- define "opencsp-console.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+fullname: Release.name + 차트 이름 조합 (중복 방지)
+*/}}
+{{- define "opencsp-console.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+공통 레이블
+*/}}
+{{- define "opencsp-console.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "opencsp-console.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+셀렉터 레이블 (Deployment/Service matchLabels)
+*/}}
+{{- define "opencsp-console.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "opencsp-console.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+BE 서비스 URL — FE가 BACKEND_URL 미설정 시 자동으로 참조
+*/}}
+{{- define "opencsp-console.beServiceURL" -}}
+{{- printf "http://%s-be:%d" (include "opencsp-console.fullname" .) (int .Values.be.service.port) }}
+{{- end }}

--- a/helm/opencsp-console/templates/be-deployment.yaml
+++ b/helm/opencsp-console/templates/be-deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "opencsp-console.fullname" . }}-be
+  labels:
+    {{- include "opencsp-console.labels" . | nindent 4 }}
+    app.kubernetes.io/component: be
+spec:
+  replicas: {{ .Values.be.replicas }}
+  selector:
+    matchLabels:
+      {{- include "opencsp-console.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: be
+  template:
+    metadata:
+      labels:
+        {{- include "opencsp-console.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: be
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: be
+          image: "{{ .Values.be.image.repository }}:{{ .Values.be.image.tag }}"
+          imagePullPolicy: {{ .Values.be.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.be.service.port }}
+              protocol: TCP
+          env:
+            {{- range $key, $val := .Values.be.env }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          {{- if .Values.be.existingSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.be.existingSecret }}
+          {{- end }}
+          startupProbe:
+            tcpSocket:
+              port: {{ .Values.be.service.port }}
+            failureThreshold: 30
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.be.service.port }}
+            initialDelaySeconds: 0
+            periodSeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.be.service.port }}
+            initialDelaySeconds: 0
+            periodSeconds: 10
+          {{- with .Values.be.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/helm/opencsp-console/templates/be-service.yaml
+++ b/helm/opencsp-console/templates/be-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opencsp-console.fullname" . }}-be
+  labels:
+    {{- include "opencsp-console.labels" . | nindent 4 }}
+    app.kubernetes.io/component: be
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.be.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "opencsp-console.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: be

--- a/helm/opencsp-console/templates/fe-deployment.yaml
+++ b/helm/opencsp-console/templates/fe-deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "opencsp-console.fullname" . }}-fe
+  labels:
+    {{- include "opencsp-console.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fe
+spec:
+  replicas: {{ .Values.fe.replicas }}
+  selector:
+    matchLabels:
+      {{- include "opencsp-console.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: fe
+  template:
+    metadata:
+      labels:
+        {{- include "opencsp-console.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: fe
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: fe
+          image: "{{ .Values.fe.image.repository }}:{{ .Values.fe.image.tag }}"
+          imagePullPolicy: {{ .Values.fe.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.fe.service.port }}
+              protocol: TCP
+          env:
+            # BACKEND_URL: 미설정 시 BE ClusterIP 서비스 URL 자동 설정
+            - name: BACKEND_URL
+              value: {{ .Values.fe.env.BACKEND_URL | default (include "opencsp-console.beServiceURL" .) | quote }}
+            {{- range $key, $val := .Values.fe.env }}
+            {{- if ne $key "BACKEND_URL" }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+            {{- end }}
+          {{- if .Values.fe.existingSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.fe.existingSecret }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.fe.service.port }}
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.fe.service.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          {{- with .Values.fe.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/helm/opencsp-console/templates/fe-service.yaml
+++ b/helm/opencsp-console/templates/fe-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opencsp-console.fullname" . }}-fe
+  labels:
+    {{- include "opencsp-console.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fe
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.fe.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "opencsp-console.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: fe

--- a/helm/opencsp-console/templates/ingress.yaml
+++ b/helm/opencsp-console/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "opencsp-console.fullname" . }}
+  labels:
+    {{- include "opencsp-console.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                # 모든 트래픽을 FE로 라우팅 (FE의 Next.js API routes가 BE 프록시)
+                name: {{ include "opencsp-console.fullname" $ }}-fe
+                port:
+                  number: {{ $.Values.fe.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/opencsp-console/values.yaml
+++ b/helm/opencsp-console/values.yaml
@@ -1,0 +1,80 @@
+# ─────────────────────────────────────────────
+# BE (Spring Boot)
+# ─────────────────────────────────────────────
+be:
+  image:
+    repository: ghcr.io/h001-lab/opencsp-console-be
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  service:
+    port: 8080
+  # 비민감 환경변수 — 키: 값 형태로 자유롭게 추가
+  # 민감한 값(ENCRYPT_KEY, DB 비밀번호 등)은 existingSecret에 k8s Secret을 지정
+  env:
+    APP_IAM_PROVIDER: "none"
+    APP_K8S_ENABLED: "false"
+    # 프로덕션 DB 연결 예시 (H2 인메모리가 기본값)
+    # SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres:5432/opencsp"
+    # SPRING_DATASOURCE_DRIVER: "org.postgresql.Driver"
+    # SPRING_JPA_DIALECT: "org.hibernate.dialect.PostgreSQLDialect"
+    # SPRING_DATASOURCE_POOL_SIZE: "5"
+  # 민감 환경변수를 담은 기존 k8s Secret 이름 (envFrom.secretRef)
+  # 포함 권장 키: APP_CONFIG_ENCRYPTION_KEY, SPRING_DATASOURCE_USERNAME,
+  #              SPRING_DATASOURCE_PASSWORD, ZITADEL_* 등
+  existingSecret: ""
+  resources: {}
+  #   requests:
+  #     cpu: 250m
+  #     memory: 512Mi
+  #   limits:
+  #     cpu: 1000m
+  #     memory: 1Gi
+
+# ─────────────────────────────────────────────
+# FE (Next.js)
+# ─────────────────────────────────────────────
+fe:
+  image:
+    repository: ghcr.io/h001-lab/opencsp-console-fe
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  service:
+    port: 3000
+  # BACKEND_URL 미설정 시 차트 내부에서 BE ClusterIP 서비스 URL을 자동 생성
+  env:
+    BACKEND_URL: ""
+    # NEXTAUTH_URL: "https://opencsp.example.com"
+  # 민감 환경변수를 담은 기존 k8s Secret 이름 (envFrom.secretRef)
+  # 포함 권장 키: NEXTAUTH_SECRET, ZITADEL_ISSUER, ZITADEL_CLIENT_ID
+  existingSecret: ""
+  resources: {}
+
+# ─────────────────────────────────────────────
+# Ingress
+# ─────────────────────────────────────────────
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  #   cert-manager.io/cluster-issuer: letsencrypt-prod
+  #   nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+  hosts:
+    - host: opencsp.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #   - secretName: opencsp-tls
+  #     hosts:
+  #       - opencsp.example.com
+
+# ─────────────────────────────────────────────
+# 공통
+# ─────────────────────────────────────────────
+imagePullSecrets: []
+#   - name: ghcr-secret
+
+nameOverride: ""
+fullnameOverride: ""


### PR DESCRIPTION
## 📝 Summary
v* 태그 push 시 BE/FE Docker 이미지를 GHCR에 빌드·배포하고,
Helm chart를 OCI 형식으로 게시하는 릴리즈 파이프라인을 추가합니다.
FluxCD를 통해 다른 레포에서 k3s 클러스터에 배포할 수 있습니다.

---

## 🔗 Related Issue
Closes #32

---

## 📦 Changes
- `be/Dockerfile`: 빌드 결과물 COPY를 `*.jar` 와일드카드로 수정 (릴리즈 버전 대응)
- `fe/Dockerfile`, `fe/.dockerignore`, `fe/next.config.ts`: Next.js standalone 멀티스테이지 빌드 추가
- `helm/opencsp-console/`: BE/FE Deployment·Service·Ingress 포함 Helm chart 신규 추가
- `.github/workflows/release.yaml`: `v*` 태그 push 시 BE/FE 이미지(병렬) 및 Helm chart OCI 자동 배포

---

## 🧪 Test Plan
- [ ] Build passes locally
- [ ] Feature works as expected
- [ ] Lint passes

---

## 📸 Screenshots (optional)

---

## 🔍 Checklist
- [x] PR title follows convention (feat/fix/chore/etc.)
- [x] No unintended changes included
- [x] No unrelated commits
- [x] PR is easy for reviewers to understand