### PR TITLE
fix(fe): Dockerfile npm@11 업그레이드 누락 수정

### DIFF
--- a/fe/Dockerfile
+++ b/fe/Dockerfile
@@ -1,6 +1,8 @@
 # deps stage — 모든 의존성 설치 (빌드용)
 FROM node:20-alpine AS deps
 WORKDIR /app
+# package-lock.json이 npm 11(lockfileVersion 4)로 생성된 경우 npm 10과 호환되지 않으므로 업그레이드
+RUN npm install -g npm@11
 COPY package.json package-lock.json ./
 RUN npm ci
 


### PR DESCRIPTION
## 📝 Summary

- `fe/Dockerfile` deps 스테이지에 `RUN npm install -g npm@11` 추가
- `node:20-alpine` 기본 npm(10.8.2)은 lockfileVersion 4 비호환 → FE 빌드 실패 원인

---

## 🔗 Related Issue

Closes #34

---

## 📦 Changes

### Frontend
- `fe/Dockerfile`: deps 스테이지에 npm@11 업그레이드 단계 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)