### PR TITLE
fix(security): Zitadel issuer-uri 미설정 시 전체 API 잠금 방지

### DIFF
--- a/be/src/main/java/io/hlab/opencsp/infrastructure/security/SecurityConfig.java
+++ b/be/src/main/java/io/hlab/opencsp/infrastructure/security/SecurityConfig.java
@@ -79,10 +79,9 @@ public class SecurityConfig {
                 .requestMatchers("/api/public/**").permitAll()
                 // WebSocket 핸드셰이크: sessionId 기반 자체 검증 (ConsoleWebSocketHandler)
                 .requestMatchers("/api/console/ws/**").permitAll()
-                // iam.provider를 요청마다 동적으로 확인
+                // iam.provider=zitadel AND issuer-uri 설정 완료된 경우에만 JWT 인증 요구
                 .anyRequest().access((authSupplier, context) -> {
-                    String provider = configStore.get(ConfigCategory.GENERAL, "iam.provider", "none");
-                    if (!"zitadel".equals(provider)) {
+                    if (!isZitadelEffective(configStore)) {
                         return new AuthorizationDecision(true);
                     }
                     Authentication authentication = authSupplier.get();
@@ -166,8 +165,7 @@ public class SecurityConfig {
         @Override
         protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
                                         @NonNull FilterChain chain) throws ServletException, IOException {
-            String provider = configStore.get(ConfigCategory.GENERAL, "iam.provider", "none");
-            if (!"zitadel".equals(provider)) {
+            if (!isZitadelEffective(configStore)) {
                 List<GrantedAuthority> authorities = List.of(
                     new SimpleGrantedAuthority("ROLE_" + IamRole.ADMIN.name()),
                     new SimpleGrantedAuthority("ROLE_" + IamRole.USER_A.name())
@@ -194,9 +192,21 @@ public class SecurityConfig {
 
         @Override
         public String resolve(HttpServletRequest request) {
-            String provider = configStore.get(ConfigCategory.GENERAL, "iam.provider", "none");
-            return "zitadel".equals(provider) ? delegate.resolve(request) : null;
+            return isZitadelEffective(configStore) ? delegate.resolve(request) : null;
         }
+    }
+
+    /**
+     * iam.provider=zitadel이고 zitadel.issuer-uri가 설정된 경우에만 true를 반환한다.
+     *
+     * issuer-uri 없이 zitadel 모드가 활성화되면 DynamicZitadelJwtDecoder가 BadJwtException을 던져
+     * 전체 API가 401로 잠기는 현상을 방지한다. issuer-uri 미설정 시 none 모드로 폴백한다.
+     */
+    static boolean isZitadelEffective(ConfigStore configStore) {
+        String provider = configStore.get(ConfigCategory.GENERAL, "iam.provider", "none");
+        if (!"zitadel".equals(provider)) return false;
+        String issuerUri = configStore.get(ConfigCategory.IAM, "zitadel.issuer-uri", "");
+        return org.springframework.util.StringUtils.hasText(issuerUri);
     }
 
     /**

--- a/fe/src/app/[locale]/admin/integrations/IamSection.tsx
+++ b/fe/src/app/[locale]/admin/integrations/IamSection.tsx
@@ -106,16 +106,22 @@ export function IamConfigSection({ configs, onSaved, t }: IamConfigSectionProps)
           body: JSON.stringify({ category: "IAM", key: field.key, value, sensitive: field.sensitive ?? false }),
         });
       }
-      await fetch("/api/admin/configs", {
+      const providerRes = await fetch("/api/admin/configs", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ category: "GENERAL", key: "iam.provider", value: provider, sensitive: false }),
       });
-      setSavedMsg({ ok: true, msg: ti.savedOk });
+      if (!providerRes.ok) {
+        const body = await providerRes.json().catch(() => null);
+        const msg = body?.message ?? body?.error ?? t.saveFailed;
+        setSavedMsg({ ok: false, msg });
+        return;
+      }
       setDirty(false);
       if (dbProvider === "none" && provider !== "none") {
         setSavedMsg({ ok: true, msg: ti.savedOk + " — " + ti.loginRequired });
       } else {
+        setSavedMsg({ ok: true, msg: ti.savedOk });
         onSaved();
       }
     } catch {


### PR DESCRIPTION
## Summary

- `isZitadelEffective()` 헬퍼 메서드 도입: `provider=zitadel` AND `zitadel.issuer-uri` 설정 완료인 경우에만 Zitadel JWT 인증 활성화
- issuer-uri 미설정 시 `none` 모드로 폴백 → `DynamicZitadelJwtDecoder`의 `BadJwtException`으로 인한 전체 API 401 잠금 방지
- `IamSection.tsx`: provider 변경 API 실패 시 서버 에러 메시지를 UI에 표시

## Test plan

- [ ] `iam.provider=zitadel`, `zitadel.issuer-uri` 미설정 상태에서 API 호출 → 인증 없이 정상 응답 (none 폴백 확인)
- [ ] `iam.provider=zitadel`, `zitadel.issuer-uri` 설정 완료 상태에서 API 호출 → JWT 인증 요구 확인
- [ ] 관리자 UI에서 issuer-uri 없이 zitadel로 전환 시도 → 에러 메시지 표시 확인

Closes #36