### PR TITLE
feature(provision): 월간 CPU 할당량 추적 및 프로비저닝 초과 방지

### DIFF
--- a/be/src/main/java/io/hlab/opencsp/api/admin/billing/AdminBillingController.java
+++ b/be/src/main/java/io/hlab/opencsp/api/admin/billing/AdminBillingController.java
@@ -1,11 +1,13 @@
 package io.hlab.opencsp.api.admin.billing;
 
+import io.hlab.opencsp.domain.config.ConfigCategory;
 import io.hlab.opencsp.domain.console.ConsoleSession;
 import io.hlab.opencsp.domain.console.ConsoleSessionRepository;
 import io.hlab.opencsp.domain.console.ConsoleSessionStatus;
 import io.hlab.opencsp.domain.provision.Provision;
 import io.hlab.opencsp.domain.provision.ProvisionRepository;
 import io.hlab.opencsp.domain.provision.ProvisionStatus;
+import io.hlab.opencsp.infrastructure.config.ConfigStore;
 import io.hlab.opencsp.infrastructure.security.JwtUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +17,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.List;
 
 /**
@@ -30,12 +34,15 @@ public class AdminBillingController {
     private final ProvisionRepository provisionRepository;
     private final ConsoleSessionRepository consoleSessionRepository;
     private final JwtUtils jwtUtils;
+    private final ConfigStore configStore;
 
     public record BillingSummary(
             long totalProvisions,
             long activeProvisions,
             long totalConsoleSessions,
-            long totalConsoleMinutes
+            long totalConsoleMinutes,
+            int monthlyCpuUsed,
+            int monthlyCpuLimit
     ) {}
 
     @GetMapping("/summary")
@@ -63,7 +70,23 @@ public class AdminBillingController {
                 .mapToLong(s -> Duration.between(s.getConnectedAt(), s.getDisconnectedAt()).toMinutes())
                 .sum();
 
+        YearMonth current = YearMonth.now();
+        LocalDateTime from = current.atDay(1).atStartOfDay();
+        LocalDateTime to = current.plusMonths(1).atDay(1).atStartOfDay();
+        int monthlyCpuUsed = userId != null
+                ? provisionRepository.sumCpuCoresByUserIdAndCreatedAtBetween(userId, from, to)
+                : 0;
+
+        String limitStr = configStore.get(ConfigCategory.PROVISION, "monthly_cpu_limit_per_user", "0");
+        int monthlyCpuLimit;
+        try {
+            monthlyCpuLimit = Integer.parseInt(limitStr);
+        } catch (NumberFormatException e) {
+            monthlyCpuLimit = 0;
+        }
+
         return ResponseEntity.ok(new BillingSummary(
-                totalProvisions, activeProvisions, totalConsoleSessions, totalConsoleMinutes));
+                totalProvisions, activeProvisions, totalConsoleSessions, totalConsoleMinutes,
+                monthlyCpuUsed, monthlyCpuLimit));
     }
 }

--- a/be/src/main/java/io/hlab/opencsp/application/provision/ProvisioningService.java
+++ b/be/src/main/java/io/hlab/opencsp/application/provision/ProvisioningService.java
@@ -11,6 +11,9 @@ import io.hlab.opencsp.domain.provision.ProvisionRepository;
 import io.hlab.opencsp.domain.provision.ProvisionStatus;
 import io.hlab.opencsp.domain.provision.SemaphoreStatus;
 import io.hlab.opencsp.application.billing.BillingService;
+import io.hlab.opencsp.common.exception.ErrorCode;
+import io.hlab.opencsp.domain.config.ConfigCategory;
+import io.hlab.opencsp.infrastructure.config.ConfigStore;
 import io.hlab.opencsp.infrastructure.k8s.ProvisionRequest;
 import io.hlab.opencsp.infrastructure.k8s.ProvisioningClient;
 import io.hlab.opencsp.infrastructure.semaphore.SemaphoreClient;
@@ -18,6 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +49,7 @@ public class ProvisioningService {
     private final ProvisionHistoryRepository provisionHistoryRepository;
     private final SemaphoreClient semaphoreClient;
     private final BillingService billingService;
+    private final ConfigStore configStore;
 
     private static final Map<String, String> DEFAULT_MODULE_PATHS = Map.of(
             "proxmox-vm",      "./bootstrap/terraform/provisions/proxmox-vm",
@@ -95,6 +100,12 @@ public class ProvisioningService {
                 }
             }
 
+            // 월간 CPU 할당량 초과 여부 확인
+            int requestedCpu = Optional.ofNullable(sanitizedVars.get("vm_cpu"))
+                    .map(v -> Integer.parseInt(v.toString()))
+                    .orElse(0);
+            checkMonthlyCpuQuota(userId, requestedCpu);
+
             ProvisionRequest request = ProvisionRequest.builder()
                     .moduleType(moduleType)
                     .modulePath(modulePath)
@@ -117,6 +128,10 @@ public class ProvisioningService {
                     .map(Object::toString)
                     .orElse(null);
             Provision saved = provisionRepository.save(Provision.create(crName, moduleType, fluxNamespace, gitRepositoryName, userId, vmId, proxmoxNode, vmHostname));
+            if (requestedCpu > 0) {
+                saved.assignCpuCores(requestedCpu);
+                provisionRepository.save(saved);
+            }
             provisionHistoryRepository.save(ProvisionHistory.created(saved));
 
             MDC.put("task_id", saved.getProvisionTaskId());
@@ -614,6 +629,38 @@ public class ProvisioningService {
             }
         }
         return ProvisionStatus.APPLYING;
+    }
+
+    /**
+     * 유저의 이번 달 CPU 코어 누적 사용량이 한도를 초과하는지 확인한다.
+     * {@code provision.monthly_cpu_limit_per_user} 설정이 없거나 0 이하이면 무제한.
+     *
+     * @throws BusinessException CPU 할당량 초과 시
+     */
+    private void checkMonthlyCpuQuota(String userId, int requestedCpu) {
+        String limitStr = configStore.get(ConfigCategory.PROVISION, "monthly_cpu_limit_per_user", "0");
+        int limit;
+        try {
+            limit = Integer.parseInt(limitStr);
+        } catch (NumberFormatException e) {
+            limit = 0;
+        }
+        if (limit <= 0) return; // 무제한
+
+        YearMonth current = YearMonth.now();
+        LocalDateTime from = current.atDay(1).atStartOfDay();
+        LocalDateTime to = current.plusMonths(1).atDay(1).atStartOfDay();
+        int used = provisionRepository.sumCpuCoresByUserIdAndCreatedAtBetween(userId, from, to);
+
+        if (used + requestedCpu > limit) {
+            log.atWarn()
+                    .addKeyValue("user_id", userId)
+                    .addKeyValue("cpu_used", used)
+                    .addKeyValue("cpu_requested", requestedCpu)
+                    .addKeyValue("cpu_limit", limit)
+                    .log("월간 CPU 할당량 초과");
+            throw ErrorCode.CPU_QUOTA_EXCEEDED.toException();
+        }
     }
 
     private String resolveModulePath(String moduleType) {

--- a/be/src/main/java/io/hlab/opencsp/common/exception/ErrorCode.java
+++ b/be/src/main/java/io/hlab/opencsp/common/exception/ErrorCode.java
@@ -17,6 +17,9 @@ public enum ErrorCode {
     IAM_ROLE_REMOVE_FAILED("IAM_ROLE_REMOVE_FAILED", "Role 제거에 실패했습니다.", 500),
     IAM_ROLE_QUERY_FAILED("IAM_ROLE_QUERY_FAILED", "Role 조회에 실패했습니다.", 500),
     
+    // 프로비저닝 관련
+    CPU_QUOTA_EXCEEDED("CPU_QUOTA_EXCEEDED", "월간 CPU 할당량을 초과했습니다.", 429),
+
     // 공통
     INVALID_INPUT("INVALID_INPUT", "잘못된 입력입니다.", 400),
     UNAUTHORIZED("UNAUTHORIZED", "인증이 필요합니다.", 401),

--- a/be/src/main/java/io/hlab/opencsp/domain/provision/Provision.java
+++ b/be/src/main/java/io/hlab/opencsp/domain/provision/Provision.java
@@ -58,6 +58,10 @@ public class Provision extends SemaphoreTrackable {
     @Column(name = "vm_hostname", length = 255)
     private String vmHostname;
 
+    /** 요청된 vCPU 코어 수 (월간 CPU 할당량 집계에 사용) */
+    @Column(name = "cpu_cores")
+    private Integer cpuCores;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private ProvisionStatus status;
@@ -104,6 +108,10 @@ public class Provision extends SemaphoreTrackable {
     public void updateVmHostname(String vmHostname) {
         this.vmHostname = vmHostname;
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public void assignCpuCores(Integer cpuCores) {
+        this.cpuCores = cpuCores;
     }
 
     public void assignTenant(String tenantId) {

--- a/be/src/main/java/io/hlab/opencsp/domain/provision/ProvisionRepository.java
+++ b/be/src/main/java/io/hlab/opencsp/domain/provision/ProvisionRepository.java
@@ -1,5 +1,6 @@
 package io.hlab.opencsp.domain.provision;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,4 +13,7 @@ public interface ProvisionRepository {
     List<Provision> findBySemaphoreStatus(SemaphoreStatus semaphoreStatus);
     void deleteByCrName(String crName);
     Optional<Long> findMaxVmId();
+
+    /** 특정 유저의 기간 내 총 CPU 코어 할당량을 합산한다 (DESTROYED 제외). */
+    int sumCpuCoresByUserIdAndCreatedAtBetween(String userId, LocalDateTime from, LocalDateTime to);
 }

--- a/be/src/main/java/io/hlab/opencsp/infrastructure/persistence/provision/ProvisionJpaRepository.java
+++ b/be/src/main/java/io/hlab/opencsp/infrastructure/persistence/provision/ProvisionJpaRepository.java
@@ -7,6 +7,7 @@ import io.hlab.opencsp.domain.provision.SemaphoreStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -54,5 +55,10 @@ public class ProvisionJpaRepository implements ProvisionRepository {
     @Override
     public Optional<Long> findMaxVmId() {
         return jpa.findMaxVmId();
+    }
+
+    @Override
+    public int sumCpuCoresByUserIdAndCreatedAtBetween(String userId, LocalDateTime from, LocalDateTime to) {
+        return jpa.sumCpuCoresByUserIdAndPeriod(userId, from, to);
     }
 }

--- a/be/src/main/java/io/hlab/opencsp/infrastructure/persistence/provision/SpringDataProvisionRepository.java
+++ b/be/src/main/java/io/hlab/opencsp/infrastructure/persistence/provision/SpringDataProvisionRepository.java
@@ -5,7 +5,9 @@ import io.hlab.opencsp.domain.provision.ProvisionStatus;
 import io.hlab.opencsp.domain.provision.SemaphoreStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,4 +20,12 @@ public interface SpringDataProvisionRepository extends JpaRepository<Provision, 
 
     @Query("SELECT MAX(p.vmId) FROM Provision p WHERE p.vmId IS NOT NULL")
     Optional<Long> findMaxVmId();
+
+    @Query("SELECT COALESCE(SUM(p.cpuCores), 0) FROM Provision p " +
+           "WHERE p.userId = :userId AND p.status <> 'DESTROYED' " +
+           "AND p.createdAt >= :from AND p.createdAt < :to")
+    int sumCpuCoresByUserIdAndPeriod(
+            @Param("userId") String userId,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to);
 }

--- a/fe/public/messages/en.json
+++ b/fe/public/messages/en.json
@@ -589,6 +589,14 @@
         "activeProvisions": "running",
         "consoleSessions": "sessions",
         "consoleMinutes": "min"
+      },
+      "cpuQuota": {
+        "title": "Monthly CPU Quota",
+        "used": "Used",
+        "limit": "Limit",
+        "unlimited": "Unlimited",
+        "unit": "cores",
+        "of": "of"
       }
     },
     "history": {

--- a/fe/public/messages/ko.json
+++ b/fe/public/messages/ko.json
@@ -589,6 +589,14 @@
         "activeProvisions": "대",
         "consoleSessions": "세션",
         "consoleMinutes": "분"
+      },
+      "cpuQuota": {
+        "title": "월간 CPU 할당량",
+        "used": "사용",
+        "limit": "한도",
+        "unlimited": "무제한",
+        "unit": "코어",
+        "of": "/"
       }
     },
     "history": {

--- a/fe/src/app/[locale]/billing/page.tsx
+++ b/fe/src/app/[locale]/billing/page.tsx
@@ -19,6 +19,14 @@ interface BillingMessages {
       consoleSessions: string;
       consoleMinutes: string;
     };
+    cpuQuota: {
+      title: string;
+      used: string;
+      limit: string;
+      unlimited: string;
+      unit: string;
+      of: string;
+    };
   };
   history: {
     title: string;
@@ -33,6 +41,8 @@ interface BillingSummary {
   activeProvisions: number;
   totalConsoleSessions: number;
   totalConsoleMinutes: number;
+  monthlyCpuUsed: number;
+  monthlyCpuLimit: number;
 }
 
 export default function BillingPage() {
@@ -101,6 +111,38 @@ export default function BillingPage() {
                 </p>
               </div>
             ))}
+          </div>
+
+          {/* Monthly CPU quota */}
+          <div className="mt-4 bg-white rounded-lg border p-4">
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-xs text-gray-500">{t.summary.cpuQuota.title}</p>
+              <p className="text-xs text-gray-500">
+                {summary
+                  ? summary.monthlyCpuLimit > 0
+                    ? `${summary.monthlyCpuUsed} ${t.summary.cpuQuota.of} ${summary.monthlyCpuLimit} ${t.summary.cpuQuota.unit}`
+                    : t.summary.cpuQuota.unlimited
+                  : "—"}
+              </p>
+            </div>
+            <div className="w-full bg-gray-100 rounded-full h-2">
+              {summary && summary.monthlyCpuLimit > 0 ? (
+                <div
+                  className="h-2 rounded-full transition-all"
+                  style={{
+                    width: `${Math.min(100, (summary.monthlyCpuUsed / summary.monthlyCpuLimit) * 100)}%`,
+                    backgroundColor:
+                      summary.monthlyCpuUsed / summary.monthlyCpuLimit >= 0.9
+                        ? "#ef4444"
+                        : summary.monthlyCpuUsed / summary.monthlyCpuLimit >= 0.7
+                          ? "#f59e0b"
+                          : "#3b82f6",
+                  }}
+                />
+              ) : (
+                <div className="h-2 rounded-full bg-blue-500" style={{ width: summary ? "8px" : "0%" }} />
+              )}
+            </div>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary

- `Provision` 엔티티에 `cpu_cores` 컬럼 추가, 프로비저닝 시 할당 vCPU 기록
- `ProvisioningService.checkMonthlyCpuQuota()`: 해당 월 누적 CPU 사용량이 `provision.monthly_cpu_limit_per_user` 초과 시 `CPU_QUOTA_EXCEEDED(429)` 반환 (0 = 무제한)
- `AdminBillingController /summary`에 `monthlyCpuUsed`, `monthlyCpuLimit` 필드 추가
- Billing 페이지 CPU 할당량 진행 바 (70% 주황 / 90% 빨강 임계값, 무제한 시 "Unlimited" 표시)
- `ErrorCode.CPU_QUOTA_EXCEEDED` 추가
- i18n: `en.json`, `ko.json` cpuQuota 메시지 추가

## Test plan

- [ ] ConfigStore `provision.monthly_cpu_limit_per_user=4` 설정 후 5코어 VM 프로비저닝 → 429 응답 확인
- [ ] 한도 미설정(0) 상태에서 프로비저닝 → 정상 동작 확인
- [ ] Billing 페이지에서 월간 CPU 사용량 진행 바 표시 확인
- [ ] 사용량 90% 초과 시 빨간색 표시 확인

Closes #37