### PR TITLE
chore(infra): BE Dockerfile tsh 설치, H2 AUTO_SERVER 제거, Helm values 문서 개선

### DIFF
--- a/be/Dockerfile
+++ b/be/Dockerfile
@@ -7,10 +7,30 @@ RUN ./gradlew dependencies --no-daemon -q || true
 COPY src/ src/
 RUN ./gradlew bootJar -x test --no-daemon
 
+# tsh download stage
+# TELEPORT_VERSION은 서버 버전과 맞춰야 한다 (major 버전 ±1 이내 권장)
+FROM alpine:3.20 AS tsh-installer
+ARG TELEPORT_VERSION=17.4.3
+RUN apk add --no-cache curl && \
+    ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && \
+    curl -fsSL "https://cdn.teleport.dev/teleport-v${TELEPORT_VERSION}-linux-${ARCH}-bin.tar.gz" \
+         -o /tmp/teleport.tar.gz && \
+    tar -xzf /tmp/teleport.tar.gz teleport/tsh && \
+    mv teleport/tsh /usr/local/bin/tsh && \
+    chmod +x /usr/local/bin/tsh
+
 # Run stage
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
-RUN addgroup -S spring && adduser -S spring -G spring
+
+# gcompat: Alpine(musl) 위에서 glibc 빌드된 tsh 바이너리를 실행하기 위한 호환 레이어
+RUN apk add --no-cache gcompat && \
+    addgroup -S spring && \
+    adduser -S spring -G spring -h /home/spring && \
+    mkdir -p /home/spring /app/data && \
+    chown -R spring:spring /home/spring /app
+
+COPY --from=tsh-installer /usr/local/bin/tsh /usr/local/bin/tsh
 USER spring
 COPY --from=builder /app/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/be/src/main/resources/application.yaml
+++ b/be/src/main/resources/application.yaml
@@ -19,7 +19,7 @@ spring:
       - org.springframework.ai.model.openai.autoconfigure.OpenAiModerationAutoConfiguration
 
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:h2:file:./data/opencsp;AUTO_SERVER=TRUE;DB_CLOSE_ON_EXIT=FALSE}
+    url: ${SPRING_DATASOURCE_URL:jdbc:h2:file:./data/opencsp;DB_CLOSE_ON_EXIT=FALSE}
     username: ${SPRING_DATASOURCE_USERNAME:sa}
     password: ${SPRING_DATASOURCE_PASSWORD:}
     driver-class-name: ${SPRING_DATASOURCE_DRIVER:org.h2.Driver}

--- a/helm/opencsp-console/values.yaml
+++ b/helm/opencsp-console/values.yaml
@@ -19,9 +19,30 @@ be:
     # SPRING_DATASOURCE_DRIVER: "org.postgresql.Driver"
     # SPRING_JPA_DIALECT: "org.hibernate.dialect.PostgreSQLDialect"
     # SPRING_DATASOURCE_POOL_SIZE: "5"
+    #
+    # ── IAM 연동 Option A (엔지니어용) ──────────────────────────────────────
+    # Zitadel 자격증명을 env 변수로 직접 주입하는 방식.
+    # existingSecret 에 아래 키를 포함한 k8s Secret을 지정하면 됩니다.
+    # ConfigStore는 DB → env 순으로 값을 읽으므로 Secret에 값이 있으면 자동으로 사용됩니다.
+    #
+    # APP_IAM_PROVIDER: "zitadel"          # env로 직접 zitadel 모드 활성화
+    # ZITADEL_ISSUER_URI: "https://..."    # ConfigCategory.IAM / zitadel.issuer-uri
+    # ZITADEL_CLIENT_ID: "..."             # ConfigCategory.IAM / zitadel.client-id
+    # ZITADEL_CLIENT_SECRET: "..."         # ConfigCategory.IAM / zitadel.client-secret
+    # ZITADEL_ORG_ID: "..."                # ConfigCategory.IAM / zitadel.org-id
+    # ZITADEL_PROJECT_ID: "..."            # ConfigCategory.IAM / zitadel.project-id
+    # ZITADEL_SERVICE_TOKEN: "..."         # ConfigCategory.IAM / zitadel.service-token
+    #
+    # ── IAM 연동 Option B (일반 사용자용) ────────────────────────────────────
+    # APP_IAM_PROVIDER: "none" (기본값) 으로 배포 후, 관리자 UI(/admin/integrations)에서
+    # Zitadel 자격증명을 먼저 입력·저장한 다음 Provider를 Zitadel로 전환합니다.
+    # 자격증명 없이 Provider를 전환하려 하면 BE가 400 오류를 반환하여 잠금 상태를 방지합니다.
   # 민감 환경변수를 담은 기존 k8s Secret 이름 (envFrom.secretRef)
   # 포함 권장 키: APP_CONFIG_ENCRYPTION_KEY, SPRING_DATASOURCE_USERNAME,
-  #              SPRING_DATASOURCE_PASSWORD, ZITADEL_* 등
+  #              SPRING_DATASOURCE_PASSWORD
+  #              Option A 사용 시: ZITADEL_ISSUER_URI, ZITADEL_CLIENT_ID,
+  #              ZITADEL_CLIENT_SECRET, ZITADEL_ORG_ID, ZITADEL_PROJECT_ID,
+  #              ZITADEL_SERVICE_TOKEN, APP_IAM_PROVIDER
   existingSecret: ""
   resources: {}
   #   requests:


### PR DESCRIPTION
## Summary

- **Dockerfile**: `tsh-installer` multi-stage 스테이지 추가로 Teleport `tsh` 바이너리 설치. Alpine(musl) 위 glibc 바이너리 실행을 위해 `gcompat` 추가. `spring` 유저 홈 및 `/app/data` 권한 정비
- **application.yaml**: H2 datasource에서 `AUTO_SERVER=TRUE` 제거 (단일 인스턴스 환경에서 포트 충돌 방지)
- **values.yaml**: IAM 연동 Option A(env 직접 주입) / Option B(관리자 UI 설정) 가이드 주석 및 `existingSecret` 키 목록 문서화

## Test plan

- [ ] `docker build` 성공 확인
- [ ] 컨테이너 내 `tsh version` 실행 확인
- [ ] H2 모드로 BE 기동 후 DB 접속 정상 동작 확인
- [ ] Helm values.yaml 주석 내용 정확성 검토

Closes #38