### PR TITLE
fix(security): IAM 인가 디버깅 로그 추가 및 AUTH_SECRET 폴백 수정

### DIFF
--- a/be/src/main/java/io/hlab/opencsp/infrastructure/config/DbEnvConfigStore.java
+++ b/be/src/main/java/io/hlab/opencsp/infrastructure/config/DbEnvConfigStore.java
@@ -38,9 +38,17 @@ public class DbEnvConfigStore implements ConfigStore {
 
     @Override
     public Optional<String> get(ConfigCategory category, String key) {
-        return repository.findByCategoryAndKey(category, key)
-                .map(AppConfig::getValue)
-                .or(() -> lookupEnv(category, key));
+        Optional<String> dbValue = repository.findByCategoryAndKey(category, key)
+                .map(AppConfig::getValue);
+        if (dbValue.isPresent()) {
+            log.atDebug()
+                    .addKeyValue("category", category)
+                    .addKeyValue("config_key", key)
+                    .addKeyValue("env_source", "db")
+                    .log("Config lookup: DB hit");
+            return dbValue;
+        }
+        return lookupEnv(category, key);
     }
 
     @Override

--- a/be/src/main/java/io/hlab/opencsp/infrastructure/security/SecurityConfig.java
+++ b/be/src/main/java/io/hlab/opencsp/infrastructure/security/SecurityConfig.java
@@ -166,6 +166,10 @@ public class SecurityConfig {
         protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response,
                                         @NonNull FilterChain chain) throws ServletException, IOException {
             if (!isZitadelEffective(configStore)) {
+                log.atDebug()
+                        .addKeyValue("request_uri", request.getRequestURI())
+                        .addKeyValue("iam_mode", "none")
+                        .log("NoIamAuthFilter: injecting ADMIN+USER_A into SecurityContext");
                 List<GrantedAuthority> authorities = List.of(
                     new SimpleGrantedAuthority("ROLE_" + IamRole.ADMIN.name()),
                     new SimpleGrantedAuthority("ROLE_" + IamRole.USER_A.name())
@@ -173,6 +177,11 @@ public class SecurityConfig {
                 SecurityContextHolder.getContext().setAuthentication(
                     new UsernamePasswordAuthenticationToken("anonymous", null, authorities)
                 );
+            } else {
+                log.atDebug()
+                        .addKeyValue("request_uri", request.getRequestURI())
+                        .addKeyValue("iam_mode", "zitadel")
+                        .log("NoIamAuthFilter: zitadel mode, skipping injection");
             }
             chain.doFilter(request, response);
         }
@@ -192,7 +201,20 @@ public class SecurityConfig {
 
         @Override
         public String resolve(HttpServletRequest request) {
-            return isZitadelEffective(configStore) ? delegate.resolve(request) : null;
+            if (!isZitadelEffective(configStore)) {
+                log.atDebug()
+                        .addKeyValue("request_uri", request.getRequestURI())
+                        .addKeyValue("iam_mode", "none")
+                        .log("BearerTokenResolver: none mode, skipping token extraction");
+                return null;
+            }
+            String token = delegate.resolve(request);
+            log.atDebug()
+                    .addKeyValue("request_uri", request.getRequestURI())
+                    .addKeyValue("iam_mode", "zitadel")
+                    .addKeyValue("token_present", token != null)
+                    .log("BearerTokenResolver: token extraction result");
+            return token;
         }
     }
 
@@ -204,9 +226,20 @@ public class SecurityConfig {
      */
     static boolean isZitadelEffective(ConfigStore configStore) {
         String provider = configStore.get(ConfigCategory.GENERAL, "iam.provider", "none");
-        if (!"zitadel".equals(provider)) return false;
+        if (!"zitadel".equals(provider)) {
+            log.atDebug()
+                    .addKeyValue("iam_provider", provider)
+                    .log("isZitadelEffective: false (provider is not zitadel)");
+            return false;
+        }
         String issuerUri = configStore.get(ConfigCategory.IAM, "zitadel.issuer-uri", "");
-        return org.springframework.util.StringUtils.hasText(issuerUri);
+        boolean effective = org.springframework.util.StringUtils.hasText(issuerUri);
+        log.atDebug()
+                .addKeyValue("iam_provider", provider)
+                .addKeyValue("issuer_uri_set", effective)
+                .addKeyValue("issuer_uri", issuerUri.isEmpty() ? "(empty)" : issuerUri)
+                .log("isZitadelEffective: " + effective);
+        return effective;
     }
 
     /**

--- a/be/src/main/resources/application.yaml
+++ b/be/src/main/resources/application.yaml
@@ -77,8 +77,9 @@ logging:
       hlab:
         opencsp:
           infrastructure:
-            security: INFO
-            iam: INFO
+            security: DEBUG
+            iam: DEBUG
+            config: DEBUG
             teleport: DEBUG
             k8s: DEBUG
     org:

--- a/fe/src/lib/backend-client.ts
+++ b/fe/src/lib/backend-client.ts
@@ -8,9 +8,10 @@ export async function callBackend(
   options?: RequestInit,
   req?: NextRequest
 ): Promise<Response> {
+  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
   const token = await getToken({
     req: req ?? ({ headers: Object.fromEntries(await headers()) } as { headers: Record<string, string> }),
-    secret: process.env.AUTH_SECRET,
+    secret,
   });
 
   const reqHeaders: Record<string, string> = {

--- a/helm/opencsp-console/values.yaml
+++ b/helm/opencsp-console/values.yaml
@@ -68,7 +68,7 @@ fe:
     BACKEND_URL: ""
     # NEXTAUTH_URL: "https://opencsp.example.com"
   # 민감 환경변수를 담은 기존 k8s Secret 이름 (envFrom.secretRef)
-  # 포함 권장 키: NEXTAUTH_SECRET, ZITADEL_ISSUER, ZITADEL_CLIENT_ID
+  # 포함 권장 키: AUTH_SECRET (또는 NEXTAUTH_SECRET), ZITADEL_ISSUER, ZITADEL_CLIENT_ID
   existingSecret: ""
   resources: {}
 


### PR DESCRIPTION
## Summary

- `SecurityConfig`: `NoIamAuthFilter`, `BearerTokenResolver`, `isZitadelEffective`에 구조화 DEBUG 로그 추가 — IAM 모드, request URI, 토큰 존재 여부, issuer-uri 설정 여부 키-값 기록
- `DbEnvConfigStore`: config 조회 시 DB hit/env fallback 여부 DEBUG 로그 추가
- `application.yaml`: `infrastructure.security`, `infrastructure.iam`, `infrastructure.config` 로그 레벨 `INFO → DEBUG`
- `backend-client.ts`: `AUTH_SECRET` 미설정 시 `NEXTAUTH_SECRET`으로 폴백 처리
- `helm/values.yaml`: FE Secret 권장 키 코멘트에 `AUTH_SECRET` 명시

## Test plan

- [ ] 운영환경 배포 후 `/configs` 호출 시 DEBUG 로그에서 `iam_mode`, `issuer_uri_set`, `token_present` 확인
- [ ] `AUTH_SECRET` 환경변수만 설정된 환경에서 FE → BE 인증 정상 동작 확인
- [ ] `NEXTAUTH_SECRET`만 설정된 환경에서도 폴백 동작 확인

Closes #42