### PR TITLE
fix(be): AppConfig 컬럼명, SEMAPHORE 키 경로, Provision null 직렬화 수정 및 노드 메트릭 저장

### DIFF
--- a/be/src/main/java/io/hlab/opencsp/api/admin/node/AdminNodeController.java
+++ b/be/src/main/java/io/hlab/opencsp/api/admin/node/AdminNodeController.java
@@ -122,6 +122,10 @@ public class AdminNodeController {
                     "CPU: %.1f%% (%d cores), Mem: %s / %s",
                     m.cpuUsagePercent(), m.cpuTotal(),
                     humanBytes(m.memUsed()), humanBytes(m.memTotal()))));
+            nodeService.updateMetrics(uuid,
+                    m.cpuUsagePercent(), m.cpuTotal(),
+                    m.memUsed(), m.memTotal(),
+                    m.diskUsed(), m.diskTotal());
             return ResponseEntity.ok(new TestResult(true, steps));
         } catch (Exception e) {
             steps.add(new TestStep("Connect", false, "연결 실패: " + e.getMessage()));

--- a/be/src/main/java/io/hlab/opencsp/api/admin/provision/AdminProvisionController.java
+++ b/be/src/main/java/io/hlab/opencsp/api/admin/provision/AdminProvisionController.java
@@ -8,6 +8,7 @@ import io.hlab.opencsp.domain.provision.ProvisionRepository;
 import io.hlab.opencsp.infrastructure.semaphore.SemaphoreClient;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -65,22 +66,22 @@ public class AdminProvisionController {
 
         Integer taskId = provision.getSemaphoreTaskId();
         if (taskId == null || taskId < 0) {
-            return ApiResponse.success(Map.of(
-                    "status",  "not_triggered",
-                    "success", false,
-                    "output",  "",
-                    "taskId",  (Object) null
-            ));
+            Map<String, Object> notTriggered = new HashMap<>();
+            notTriggered.put("status",  "not_triggered");
+            notTriggered.put("success", false);
+            notTriggered.put("output",  "");
+            notTriggered.put("taskId",  null);
+            return ApiResponse.success(notTriggered);
         }
 
         SemaphoreClient.TaskResult result = semaphoreClient.getTaskResult(taskId);
-        return ApiResponse.success(Map.of(
-                "status",      result.status(),
-                "success",     result.success(),
-                "output",      result.output(),
-                "taskId",      taskId,
-                "templateId",  provision.getSemaphoreTemplateId(),
-                "inventoryId", provision.getSemaphoreInventoryId()
-        ));
+        Map<String, Object> resp = new HashMap<>();
+        resp.put("status",      result.status());
+        resp.put("success",     result.success());
+        resp.put("output",      result.output());
+        resp.put("taskId",      taskId);
+        resp.put("templateId",  provision.getSemaphoreTemplateId());
+        resp.put("inventoryId", provision.getSemaphoreInventoryId());
+        return ApiResponse.success(resp);
     }
 }

--- a/be/src/main/java/io/hlab/opencsp/domain/config/AppConfig.java
+++ b/be/src/main/java/io/hlab/opencsp/domain/config/AppConfig.java
@@ -41,7 +41,7 @@ public class AppConfig {
     private String key;
 
     /** sensitive=true 이면 AES 암호화 저장 */
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "config_value", columnDefinition = "TEXT")
     @Convert(converter = EncryptedStringConverter.class)
     private String value;
 

--- a/be/src/main/java/io/hlab/opencsp/infrastructure/config/DbEnvConfigStore.java
+++ b/be/src/main/java/io/hlab/opencsp/infrastructure/config/DbEnvConfigStore.java
@@ -123,7 +123,7 @@ public class DbEnvConfigStore implements ConfigStore {
             case IAM       -> key;                      // e.g. zitadel.issuer-uri
             case K8S       -> "app.k8s." + key;         // e.g. app.k8s.enabled
             case AI        -> "spring.ai." + key;       // e.g. spring.ai.openai.api-key
-            case SEMAPHORE -> "semaphore." + key;
+            case SEMAPHORE -> key;
             case PROVISION -> "app.provision." + key;   // e.g. app.provision.history-retention-days
             case BILLING   -> "billing." + key;          // e.g. billing.lago.url
             case GENERAL   -> "app." + key;


### PR DESCRIPTION
## 📝 Summary

백엔드 운영 중 발견된 설정/API 버그 수정 및 소규모 기능 추가.

- `AppConfig.value` 컬럼에 `name="config_value"` 명시 → SQLite 예약어 충돌 방지
- `DbEnvConfigStore`: SEMAPHORE 그룹 키에 `semaphore.` prefix 이중 적용 버그 제거
- `AdminProvisionController`: `Map.of()` null value 삽입 시 `NullPointerException` 발생 → `HashMap`으로 교체
- `AdminNodeController`: 노드 연결 테스트 성공 시 CPU/메모리/디스크 메트릭 DB 자동 저장

---

## 🔗 Related Issue

Closes #44

---

## 📦 Changes

- `be/src/main/java/io/hlab/opencsp/domain/config/AppConfig.java`
- `be/src/main/java/io/hlab/opencsp/infrastructure/config/DbEnvConfigStore.java`
- `be/src/main/java/io/hlab/opencsp/api/admin/provision/AdminProvisionController.java`
- `be/src/main/java/io/hlab/opencsp/api/admin/node/AdminNodeController.java`

---

## 🧪 Test Plan

- [ ] Build passes (`./gradlew build`)
- [ ] SEMAPHORE 설정 저장/조회 정상 동작 확인
- [ ] 노드 연결 테스트 후 metrics DB 저장 확인
- [ ] Provision task 조회 API null taskId 케이스 정상 응답 확인

---

## 🔍 Checklist
- [x] PR title follows convention (feat/fix/chore/etc.)
- [x] No unintended changes included
- [x] No unrelated commits
- [x] PR is easy for reviewers to understand