### PR TITLE
chore: 운영 환경 설정 개선 (Actuator health, SQLite WAL, Docker make targets)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ data/
 *.log
 *.db
 *.db-*
+
+# tmporary files
+tmp/

--- a/be/.env.sample
+++ b/be/.env.sample
@@ -37,7 +37,7 @@ ZITADEL_SERVICE_TOKEN=
 # SPRING_DATASOURCE_DRIVER=org.h2.Driver
 
 # sqlite default 설정 (파일 기반, ./opencsp.db)
-SPRING_DATASOURCE_URL=jdbc:sqlite:./opencsp.db
+SPRING_DATASOURCE_URL=jdbc:sqlite:./opencsp.db?journal_mode=WAL&busy_timeout=5000
 SPRING_DATASOURCE_DRIVER=org.sqlite.JDBC
 SPRING_JPA_DIALECT=org.hibernate.community.dialect.SQLiteDialect
 

--- a/be/Makefile
+++ b/be/Makefile
@@ -16,3 +16,14 @@ run-docker:
 
 clean:
 	./gradlew clean
+
+docker-build:
+	docker build -t opencsp-be:latest . 
+
+docker-run:
+	docker run --rm -v $(shell pwd)/.env:/app/.env -p 8080:8080 opencsp-be:latest
+
+docker-clean:
+	docker rmi opencsp-be:latest
+	docker system prune -f
+

--- a/be/src/main/resources/application.yaml
+++ b/be/src/main/resources/application.yaml
@@ -66,6 +66,16 @@ spring:
           temperature: ${SPRING_AI_OPENAI_CHAT_OPTIONS_TEMPERATURE:0.0}
           max-tokens: ${SPRING_AI_OPENAI_CHAT_OPTIONS_MAX_TOKENS:1024}
 
+# Spring Boot Actuator 헬스 체크 엔드포인트 노출
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health"
+  endpoint:
+    health:
+      show-details: always
+
 logging:
   structured:
     format:
@@ -77,8 +87,8 @@ logging:
       hlab:
         opencsp:
           infrastructure:
-            security: DEBUG
-            iam: DEBUG
+            security: INFO
+            iam: INFO
             config: DEBUG
             teleport: DEBUG
             k8s: DEBUG

--- a/fe/.env.example
+++ b/fe/.env.example
@@ -6,6 +6,7 @@ BACKEND_URL=http://localhost:8080
 # BACKEND_CONFIG_PATH=/data/backend-config.json
 
 ZITADEL_ISSUER=https://zitadel-domain
+ZITADEL_ORG_ID=your-org-id
 ZITADEL_CLIENT_ID=your-client-id
 
 NEXTAUTH_URL=http://localhost:3000


### PR DESCRIPTION
## 📝 Summary

로컬 개발 및 Docker 운영 환경의 편의성과 안정성을 위한 설정 개선.

- `application.yaml`: `/actuator/health` 엔드포인트 노출, security/iam 로그 레벨 DEBUG → INFO
- `be/.env.sample`: SQLite `journal_mode=WAL&busy_timeout=5000` 설정으로 동시 쓰기 충돌 방지
- `be/Makefile`: `docker-build`, `docker-run`, `docker-clean` make target 추가
- `.gitignore`: `tmp/` 디렉토리 추가
- `fe/.env.example`: `ZITADEL_ORG_ID` 환경변수 추가

---

## 🔗 Related Issue

Closes #45

---

## 📦 Changes

- `be/src/main/resources/application.yaml`
- `be/.env.sample`
- `be/Makefile`
- `.gitignore`
- `fe/.env.example`

---

## 🧪 Test Plan

- [ ] `make docker-build && make docker-run` 정상 동작
- [ ] `/actuator/health` 엔드포인트 응답 확인
- [ ] SQLite WAL 모드에서 동시 쓰기 오류 없음 확인

---

## 🔍 Checklist
- [x] PR title follows convention (feat/fix/chore/etc.)
- [x] No unintended changes included
- [x] No unrelated commits
- [x] PR is easy for reviewers to understand