### PR TITLE
chore: Docker 빌드 환경 개선 및 운영 설정 정비 (Node 22, docker-compose, auth trustHost)

### DIFF
--- a/be/src/main/java/io/hlab/opencsp/infrastructure/security/SecurityConfig.java
+++ b/be/src/main/java/io/hlab/opencsp/infrastructure/security/SecurityConfig.java
@@ -74,6 +74,7 @@ public class SecurityConfig {
             // MDC iam_session_id 설정 (BearerTokenAuthenticationFilter 이후 — SecurityContext 채워진 뒤)
             .addFilterAfter(new MdcContextFilter(), BearerTokenAuthenticationFilter.class)
             .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/actuator/**").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                 .requestMatchers("/login/**", "/oauth2/**").permitAll()
                 .requestMatchers("/api/public/**").permitAll()

--- a/be/src/main/resources/application.yaml
+++ b/be/src/main/resources/application.yaml
@@ -32,6 +32,7 @@ spring:
     hibernate:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
     show-sql: ${SPRING_JPA_SHOW_SQL:false}
+    open-in-view: false
     properties:
       hibernate:
         dialect: ${SPRING_JPA_DIALECT:org.hibernate.dialect.H2Dialect}
@@ -89,9 +90,9 @@ logging:
           infrastructure:
             security: INFO
             iam: INFO
-            config: DEBUG
-            teleport: DEBUG
-            k8s: DEBUG
+            config: INFO
+            teleport: INFO
+            k8s: INFO
     org:
       springframework:
         ai:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+services:
+  be:
+    image: opencsp-be:latest
+    ports:
+      - "8080:8080"
+    env_file:
+      - ./be/.env
+
+  fe:
+    image: opencsp-fe:latest
+    ports:
+      - "3000:3000"
+    env_file:
+      - ./fe/.env
+    environment:
+      BACKEND_URL: "http://be:8080"  # .env의 BACKEND_URL을 덮어씀
+    depends_on:
+      - be

--- a/fe/Dockerfile
+++ b/fe/Dockerfile
@@ -1,13 +1,13 @@
 # deps stage — 모든 의존성 설치 (빌드용)
-FROM node:20-alpine AS deps
+FROM node:22.19.0-alpine AS deps
 WORKDIR /app
-# package-lock.json이 npm 11(lockfileVersion 4)로 생성된 경우 npm 10과 호환되지 않으므로 업그레이드
-RUN npm install -g npm@11
+RUN npm install -g npm@11.13.0 
 COPY package.json package-lock.json ./
-RUN npm ci
+# RUN npm ci
+RUN npm install --legacy-peer-deps
 
 # builder stage — Next.js standalone 빌드
-FROM node:20-alpine AS builder
+FROM node:22.19.0-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -15,7 +15,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 
 # runner stage — 최소 런타임 이미지
-FROM node:20-alpine AS runner
+FROM node:22.19.0-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/fe/Makefile
+++ b/fe/Makefile
@@ -13,3 +13,14 @@ build:
 	npm run build
 test:
 	npm run test
+
+docker-build:
+	docker build -t opencsp-fe:latest . 
+
+docker-run:
+	docker run --rm -v $(shell pwd)/.env:/app/.env -p 3000:3000 opencsp-fe:latest
+
+docker-clean:
+	docker rmi opencsp-fe:latest
+	docker system prune -f
+

--- a/fe/src/lib/auth.ts
+++ b/fe/src/lib/auth.ts
@@ -34,6 +34,7 @@ interface ZitadelProfile {
 }
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
+  trustHost: true,
   providers: [
     Zitadel({
       issuer: process.env.ZITADEL_ISSUER,


### PR DESCRIPTION
## 📝 Summary

Docker 빌드 환경 및 운영 설정 전반 개선.

- `fe/Dockerfile`: Node.js 20 → 22.19.0 업그레이드, npm 11.13.0 버전 고정, `npm ci` → `npm install --legacy-peer-deps` 전환으로 의존성 충돌 해결
- `fe/auth.ts`: `trustHost: true` 추가 — Docker/리버스 프록시 환경에서 NextAuth 인증 오류 수정
- `fe/Makefile`: `docker-build`, `docker-run`, `docker-clean` make target 추가
- `be/SecurityConfig`: `/actuator/**` permitAll 추가 (헬스체크 엔드포인트 인증 우회)
- `be/application.yaml`: JPA `open-in-view: false` 설정, config/teleport/k8s 로그 레벨 DEBUG → INFO 정상화
- `docker-compose.yaml`: be + fe 통합 실행을 위한 compose 파일 신규 추가

---

## 🔗 Related Issue

Closes #53

---

## 📦 Changes

- `fe/Dockerfile`
- `fe/Makefile`
- `fe/src/lib/auth.ts`
- `be/src/main/resources/application.yaml`
- `be/src/main/java/.../SecurityConfig.java`
- `docker-compose.yaml` (신규)

---

## 🧪 Test Plan

- [x] `docker compose up` 으로 be + fe 통합 실행 확인
- [x] fe Docker 이미지 빌드 성공 확인 (Node 22 기반)
- [x] `/actuator/health` 인증 없이 200 응답 확인
- [x] Docker 환경에서 NextAuth 로그인 정상 동작 확인

---

## 🔍 Checklist
- [x] PR title follows convention (feat/fix/chore/etc.)
- [x] No unintended changes included
- [x] No unrelated commits
- [x] PR is easy for reviewers to understand