### PR TITLE
fix(fe): Next.js standalone 빌드 시 next-auth 패키지 누락 수정

### DIFF
--- a/fe/next.config.ts
+++ b/fe/next.config.ts
@@ -3,9 +3,18 @@ import type { NextConfig } from "next";
 const config: NextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@h001/ui"],
-  // Docker 컨테이너 빌드용 standalone 출력 모드
-  // standalone 모드: .next/standalone/ 에 server.js + 필요한 node_modules만 포함
+  // Next.js standalone 모드 활성화
   output: "standalone",
+  outputFileTracingIncludes: {
+    "/**/*": [
+      "./node_modules/next-auth/**/*",
+      "./node_modules/@auth/**/*",
+      "./node_modules/oauth4webapi/**/*",
+      "./node_modules/jose/**/*",
+      "./node_modules/preact/**/*",
+      "./node_modules/preact-render-to-string/**/*",
+    ],
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Summary

- `outputFileTracingIncludes` 설정 추가 (`fe/next.config.ts`)
- standalone 빌드 시 파일 추적에서 누락되는 패키지를 명시적으로 포함시킴
- 대상: `next-auth`, `@auth`, `oauth4webapi`, `jose`, `preact`, `preact-render-to-string`

Closes #55

## Test plan

- [ ] `npm run build` 실행 후 `.next/standalone/` 내 위 패키지들이 포함되어 있는지 확인
- [ ] Docker 이미지 빌드 후 컨테이너 기동 시 인증 관련 런타임 오류 없는지 확인