### PR TITLE
fix(fe): Next.js standalone 모드 제거 및 일반 빌드 방식으로 전환

### DIFF
--- a/fe/Dockerfile
+++ b/fe/Dockerfile
@@ -1,12 +1,11 @@
-# deps stage — 모든 의존성 설치 (빌드용)
+# deps stage
 FROM node:22.19.0-alpine AS deps
 WORKDIR /app
-RUN npm install -g npm@11.13.0 
+RUN npm install -g npm@11.13.0
 COPY package.json package-lock.json ./
-# RUN npm ci
 RUN npm install --legacy-peer-deps
 
-# builder stage — Next.js standalone 빌드
+# builder stage
 FROM node:22.19.0-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
@@ -14,24 +13,23 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 
-# runner stage — 최소 런타임 이미지
+# runner stage
 FROM node:22.19.0-alpine AS runner
 WORKDIR /app
-
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
-
 RUN addgroup --system --gid 1001 nodejs \
- && adduser  --system --uid 1001 nextjs
+ && adduser --system --uid 1001 nextjs
 
-# standalone 빌드 결과물 복사
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/package-lock.json ./package-lock.json
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder /app/next.config.ts ./next.config.ts
 
 USER nextjs
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
-
-CMD ["node", "server.js"]
+CMD ["npx", "next", "start"]

--- a/fe/next.config.ts
+++ b/fe/next.config.ts
@@ -4,17 +4,17 @@ const config: NextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@h001/ui"],
   // Next.js standalone 모드 활성화
-  output: "standalone",
-  outputFileTracingIncludes: {
-    "/**/*": [
-      "./node_modules/next-auth/**/*",
-      "./node_modules/@auth/**/*",
-      "./node_modules/oauth4webapi/**/*",
-      "./node_modules/jose/**/*",
-      "./node_modules/preact/**/*",
-      "./node_modules/preact-render-to-string/**/*",
-    ],
-  },
+  // output: "standalone",
+  // outputFileTracingIncludes: {
+  //   "/**/*": [
+  //     "./node_modules/next-auth/**/*",
+  //     "./node_modules/@auth/**/*",
+  //     "./node_modules/oauth4webapi/**/*",
+  //     "./node_modules/jose/**/*",
+  //     "./node_modules/preact/**/*",
+  //     "./node_modules/preact-render-to-string/**/*",
+  //   ],
+  // },
 };
 
 export default config;


### PR DESCRIPTION
## 📝 Summary

PR #55의 `outputFileTracingIncludes` 접근법으로도 standalone 빌드 시 패키지 누락 문제가 해결되지 않아, standalone 모드 자체를 제거하고 일반 빌드 방식(`npx next start`)으로 전환.

---

## 🔗 Related Issue

Closes #57

---

## 📦 Changes

- `fe/next.config.ts`: `output: "standalone"` 및 `outputFileTracingIncludes` 설정 제거
- `fe/Dockerfile`: runner 스테이지를 standalone 방식에서 일반 빌드 방식으로 변경
  - `node server.js` → `npx next start`
  - standalone 결과물 대신 전체 `node_modules`, `.next`, `package.json` 복사

---

## 🧪 Test Plan

- [x] Build passes locally (`npm run build`)
- [x] Docker 이미지 빌드 및 컨테이너 정상 기동 확인
- [x] `npx next start` 실행 시 next-auth 관련 오류 없음 확인
- [x] Lint passes

---

## 📸 Screenshots (optional)

---

## 🔍 Checklist
- [x] PR title follows convention (feat/fix/chore/etc.)
- [x] No unintended changes included
- [x] No unrelated commits
- [x] PR is easy for reviewers to understand