### PR TITLE
fix(fe): NextAuth v5 쿠키명 동적 감지 및 리버스 프록시 환경 대응

### DIFF
--- a/.claude/commands/pr-create.md
+++ b/.claude/commands/pr-create.md
@@ -1,0 +1,9 @@
+변경된 파일들을 분석해서 비슷한 수정 사항들끼리 분류한 후에 아래를 순서대로 진행해줘.
+- issue 생성 (이전 이슈 양식 참고)
+- 브랜치 생성 (feature/{issue-number}-description)
+- 커밋 생성 (feature(scope): description)
+- PR 생성 (PR_template 참조)
+
+응답 및 결과는 간결하게, 문제 있는 것만 리스트로.
+
+$ARGUMENTS

--- a/fe/src/lib/backend-client.ts
+++ b/fe/src/lib/backend-client.ts
@@ -3,15 +3,32 @@ import { headers } from "next/headers";
 import { NextRequest } from "next/server";
 import { getBackendUrl } from "./backend-store";
 
+// NextAuth v5 uses 'authjs' cookie prefix (v4 used 'next-auth').
+// Detect HTTPS from x-forwarded-proto rather than NEXTAUTH_URL,
+// because NEXTAUTH_URL may be absent behind a reverse proxy.
+async function getSessionCookieName(req?: NextRequest): Promise<string> {
+  let isHttps = false;
+  if (req) {
+    isHttps = req.headers.get("x-forwarded-proto") === "https" || req.url.startsWith("https://");
+  } else {
+    const h = await headers();
+    isHttps = h.get("x-forwarded-proto") === "https";
+  }
+  return isHttps ? "__Secure-authjs.session-token" : "authjs.session-token";
+}
+
 export async function callBackend(
   path: string,
   options?: RequestInit,
   req?: NextRequest
 ): Promise<Response> {
   const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
+  const cookieName = await getSessionCookieName(req);
   const token = await getToken({
     req: req ?? ({ headers: Object.fromEntries(await headers()) } as { headers: Record<string, string> }),
     secret,
+    cookieName,
+    salt: cookieName,
   });
 
   const reqHeaders: Record<string, string> = {


### PR DESCRIPTION
## 📝 Summary

리버스 프록시 뒤 환경에서 `NEXTAUTH_URL` 부재 시 NextAuth v5가 잘못된 쿠키명을 참조해 인증 실패하는 문제 수정. `x-forwarded-proto` 헤더 기반으로 HTTPS 여부를 감지하고 `getToken()` 호출 시 `cookieName`/`salt`를 명시적으로 전달.

---

## 🔗 Related Issue

Closes #59

---

## 📦 Changes

- `fe/src/lib/backend-client.ts`: `getSessionCookieName()` 헬퍼 추가, `getToken()` 에 `cookieName`, `salt` 옵션 전달

---

## 🧪 Test Plan

- [ ] Build passes locally
- [ ] HTTP 환경: `authjs.session-token` 쿠키로 정상 인증 확인
- [ ] HTTPS/리버스 프록시 환경: `__Secure-authjs.session-token` 쿠키로 정상 인증 확인
- [ ] Lint passes

---

## 📸 Screenshots (optional)

---

## 🔍 Checklist
- [x] PR title follows convention (feat/fix/chore/etc.)
- [x] No unintended changes included
- [x] No unrelated commits
- [x] PR is easy for reviewers to understand