### PR TITLE
feat(helm): PAM/Teleport 통합 — BE에 tbot sidecar 자동 주입 지원

### DIFF
--- a/helm/opencsp-console/Chart.yaml
+++ b/helm/opencsp-console/Chart.yaml
@@ -3,7 +3,7 @@ name: opencsp-console
 description: OpenCSP Console — self-hosted cloud platform console (Proxmox + cloud-native)
 type: application
 # version / appVersion은 release.yaml에서 --version / --app-version 플래그로 덮어씀
-version: 0.1.0
+version: 0.1.10
 appVersion: "latest"
 home: https://github.com/h001-lab/OpenCSP-console
 sources:

--- a/helm/opencsp-console/templates/_helpers.tpl
+++ b/helm/opencsp-console/templates/_helpers.tpl
@@ -45,3 +45,67 @@ BE 서비스 URL — FE가 BACKEND_URL 미설정 시 자동으로 참조
 {{- define "opencsp-console.beServiceURL" -}}
 {{- printf "http://%s-be:%d" (include "opencsp-console.fullname" .) (int .Values.be.service.port) }}
 {{- end }}
+
+{{/*
+PAM이 활성화되어 있는지 — provider가 비어있지 않으면 true.
+사용처: be-deployment에서 sidecar/volume 주입 여부 판단.
+*/}}
+{{- define "opencsp-console.pamEnabled" -}}
+{{- if .Values.pam.provider -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+PAM이 사용할 ServiceAccount 이름. provider별로 다름.
+*/}}
+{{- define "opencsp-console.pamServiceAccountName" -}}
+{{- if eq .Values.pam.provider "teleport" -}}
+{{- .Values.pam.teleport.serviceAccountName -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+PAM sidecar (initContainer with restartPolicy: Always for K8s 1.29+ native sidecar).
+provider에 따라 적절한 sidecar 정의를 렌더.
+*/}}
+{{- define "opencsp-console.pamSidecar" -}}
+{{- if eq .Values.pam.provider "teleport" -}}
+- name: tbot
+  image: "{{ .Values.pam.teleport.image.repository }}:{{ .Values.pam.teleport.image.tag | default .Chart.AppVersion }}"
+  imagePullPolicy: {{ .Values.pam.teleport.image.pullPolicy }}
+  restartPolicy: Always
+  args:
+    - start
+    - --config=/etc/tbot/tbot.yaml
+  volumeMounts:
+    - name: pam-identity
+      mountPath: {{ .Values.pam.identityMountPath }}
+    - name: pam-config
+      mountPath: /etc/tbot
+      readOnly: true
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
+  {{- with .Values.pam.teleport.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+PAM이 추가하는 volumes. provider에 따라 다른 볼륨 세트를 렌더.
+공통 규칙: pam-identity는 sidecar가 자격증명을 쓰고 BE가 읽는 emptyDir.
+*/}}
+{{- define "opencsp-console.pamVolumes" -}}
+{{- if eq .Values.pam.provider "teleport" -}}
+- name: pam-identity
+  emptyDir: {}
+- name: pam-config
+  configMap:
+    name: {{ include "opencsp-console.fullname" . }}-pam-config
+{{- end -}}
+{{- end -}}

--- a/helm/opencsp-console/templates/be-deployment.yaml
+++ b/helm/opencsp-console/templates/be-deployment.yaml
@@ -21,6 +21,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if include "opencsp-console.pamEnabled" . }}
+      serviceAccountName: {{ include "opencsp-console.pamServiceAccountName" . }}
+      initContainers:
+        {{- include "opencsp-console.pamSidecar" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: be
           image: "{{ .Values.be.image.repository }}:{{ .Values.be.image.tag }}"
@@ -54,7 +59,17 @@ spec:
               port: {{ .Values.be.service.port }}
             initialDelaySeconds: 0
             periodSeconds: 10
+          {{- if include "opencsp-console.pamEnabled" . }}
+          volumeMounts:
+            - name: pam-identity
+              mountPath: {{ .Values.pam.identityMountPath }}
+              readOnly: true
+          {{- end }}
           {{- with .Values.be.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if include "opencsp-console.pamEnabled" . }}
+      volumes:
+        {{- include "opencsp-console.pamVolumes" . | nindent 8 }}
+      {{- end }}

--- a/helm/opencsp-console/templates/teleport-configmap.yaml
+++ b/helm/opencsp-console/templates/teleport-configmap.yaml
@@ -1,0 +1,33 @@
+{{- if eq .Values.pam.provider "teleport" }}
+{{- if and (not .Values.pam.teleport.authServer) (not .Values.pam.teleport.proxyServer) -}}
+{{- fail "pam.provider=teleport requires either pam.teleport.authServer or pam.teleport.proxyServer" -}}
+{{- end }}
+{{- if not .Values.pam.teleport.token -}}
+{{- fail "pam.provider=teleport requires pam.teleport.token (Teleport ProvisionToken name)" -}}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "opencsp-console.fullname" . }}-pam-config
+  labels:
+    {{- include "opencsp-console.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pam-teleport
+data:
+  tbot.yaml: |
+    version: v2
+    {{- if .Values.pam.teleport.authServer }}
+    auth_server: {{ .Values.pam.teleport.authServer }}
+    {{- else }}
+    proxy_server: {{ .Values.pam.teleport.proxyServer }}
+    {{- end }}
+    onboarding:
+      join_method: kubernetes
+      token: {{ .Values.pam.teleport.token | quote }}
+    storage:
+      type: memory
+    outputs:
+      - type: identity
+        destination:
+          type: directory
+          path: {{ .Values.pam.identityMountPath }}
+{{- end }}

--- a/helm/opencsp-console/templates/teleport-serviceaccount.yaml
+++ b/helm/opencsp-console/templates/teleport-serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if eq .Values.pam.provider "teleport" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.pam.teleport.serviceAccountName }}
+  labels:
+    {{- include "opencsp-console.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pam-teleport
+{{- end }}

--- a/helm/opencsp-console/values.yaml
+++ b/helm/opencsp-console/values.yaml
@@ -99,3 +99,47 @@ imagePullSecrets: []
 
 nameOverride: ""
 fullnameOverride: ""
+
+# ─────────────────────────────────────────────
+# PAM (Privileged Access Management) 통합
+#
+# BE에 PAM 도구의 sidecar를 주입해서 인증서/토큰을 받아오는 구조.
+# provider 값에 따라 어떤 PAM 도구와 연동할지 결정.
+#
+# provider: ""           → PAM 통합 없음 (기본값)
+# provider: "teleport"   → Teleport tbot sidecar 자동 주입
+# provider: "<other>"    → 향후 추가 예정
+#
+# 공통 동작: BE 컨테이너의 identityMountPath에 PAM이 발급한 자격증명이 마운트됨.
+# BE 앱은 provider에 상관없이 이 경로에서 인증서를 읽어 사용하면 됨.
+# ─────────────────────────────────────────────
+pam:
+  provider: ""
+  
+  # BE 컨테이너 안에서 자격증명이 마운트될 경로 (provider 공통)
+  identityMountPath: /var/pam/identity
+
+  # ── Teleport 전용 설정 (provider: "teleport"일 때 사용) ──
+  teleport:
+    # Teleport 서버 주소. 클러스터 내부면 authServer 권장.
+    # 둘 중 하나만 채우면 됨. 둘 다 비어있으면 chart render 시점에 fail.
+    authServer: ""    # 예: teleport-teleport-cluster-auth.teleport.svc.cluster.local:3025
+    proxyServer: ""   # 예: teleport.example.com:443
+    
+    # Teleport ProvisionToken 리소스 이름 (값이 아닌 이름 참조)
+    token: ""
+    
+    # tbot이 K8s join 시 사용할 SA. chart가 만들어줌.
+    serviceAccountName: opencsp-tbot
+    
+    image:
+      repository: public.ecr.aws/gravitational/tbot-distroless
+      tag: ""    # 비우면 Chart.appVersion 사용. tbot 버전을 명시하려면 직접 지정.
+      pullPolicy: IfNotPresent
+    
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 64Mi


### PR DESCRIPTION
## 📝 Summary

Helm chart에 PAM 통합 레이어를 추가. `pam.provider: teleport` 설정 시 BE 파드에 tbot sidecar가 자동으로 주입되어 Teleport 인증서 기반 SSH 접근을 지원.

---

## 🔗 Related Issue

Closes #63

---

## 📦 Changes

- `values.yaml`: `pam` 섹션 추가 (provider, identityMountPath, teleport 전용 설정)
- `_helpers.tpl`: `pamEnabled` / `pamServiceAccountName` / `pamSidecar` / `pamVolumes` 헬퍼 추가
- `be-deployment.yaml`: `pam.provider` 값에 따라 serviceAccount·initContainers(sidecar)·volumes·volumeMounts 조건부 주입
- `teleport-configmap.yaml` (신규): tbot.yaml ConfigMap (authServer/proxyServer·token·output path 포함)
- `teleport-serviceaccount.yaml` (신규): tbot용 ServiceAccount
- `Chart.yaml`: version 0.1.10 범프

---

## 🧪 Test Plan

- [ ] `helm template . --set pam.provider=""` — PAM 관련 리소스 없음 확인
- [ ] `helm template . --set pam.provider=teleport --set pam.teleport.authServer=... --set pam.teleport.token=...` — tbot sidecar·ConfigMap·SA 렌더 확인
- [ ] `authServer`/`proxyServer` 모두 비어있으면 `helm template` fail 확인
- [ ] `token` 비어있으면 `helm template` fail 확인

---

## 🔍 Checklist
- [x] PR title follows convention (feat/fix/chore/etc.)
- [x] No unintended changes included
- [x] No unrelated commits
- [x] PR is easy for reviewers to understand