### PR TITLE
fix(helm): tbot identity 공유 방식을 emptyDir에서 K8s Secret으로 변경

### DIFF
--- a/helm/opencsp-console/Chart.yaml
+++ b/helm/opencsp-console/Chart.yaml
@@ -3,7 +3,7 @@ name: opencsp-console
 description: OpenCSP Console — self-hosted cloud platform console (Proxmox + cloud-native)
 type: application
 # version / appVersion은 release.yaml에서 --version / --app-version 플래그로 덮어씀
-version: 0.1.10
+version: 0.1.11
 appVersion: "latest"
 home: https://github.com/h001-lab/OpenCSP-console
 sources:

--- a/helm/opencsp-console/templates/_helpers.tpl
+++ b/helm/opencsp-console/templates/_helpers.tpl
@@ -63,9 +63,13 @@ PAM이 사용할 ServiceAccount 이름. provider별로 다름.
 {{- end -}}
 {{- end -}}
 
+
 {{/*
 PAM sidecar (initContainer with restartPolicy: Always for K8s 1.29+ native sidecar).
 provider에 따라 적절한 sidecar 정의를 렌더.
+
+teleport 모드: tbot이 K8s Secret을 매개로 identity를 BE에 공유.
+sidecar는 config 파일만 마운트하고, identity는 K8s API로 직접 Secret에 write.
 */}}
 {{- define "opencsp-console.pamSidecar" -}}
 {{- if eq .Values.pam.provider "teleport" -}}
@@ -77,8 +81,6 @@ provider에 따라 적절한 sidecar 정의를 렌더.
     - start
     - --config=/etc/tbot/tbot.yaml
   volumeMounts:
-    - name: pam-identity
-      mountPath: {{ .Values.pam.identityMountPath }}
     - name: pam-config
       mountPath: /etc/tbot
       readOnly: true
@@ -98,12 +100,19 @@ provider에 따라 적절한 sidecar 정의를 렌더.
 
 {{/*
 PAM이 추가하는 volumes. provider에 따라 다른 볼륨 세트를 렌더.
-공통 규칙: pam-identity는 sidecar가 자격증명을 쓰고 BE가 읽는 emptyDir.
+
+teleport 모드:
+- pam-identity: tbot이 갱신하는 K8s Secret을 BE 컨테이너에 read-only로 마운트.
+                kubelet이 sync해주므로 UID 충돌 없이 0440으로 누구나 읽기 가능.
+- pam-config:   tbot 설정 ConfigMap.
 */}}
 {{- define "opencsp-console.pamVolumes" -}}
 {{- if eq .Values.pam.provider "teleport" -}}
 - name: pam-identity
-  emptyDir: {}
+  secret:
+    secretName: {{ include "opencsp-console.fullname" . }}-pam-identity
+    defaultMode: 0440
+    optional: true
 - name: pam-config
   configMap:
     name: {{ include "opencsp-console.fullname" . }}-pam-config

--- a/helm/opencsp-console/templates/teleport-configmap.yaml
+++ b/helm/opencsp-console/templates/teleport-configmap.yaml
@@ -28,6 +28,6 @@ data:
     outputs:
       - type: identity
         destination:
-          type: directory
-          path: {{ .Values.pam.identityMountPath }}
+          type: kubernetes_secret
+          name: {{ include "opencsp-console.fullname" . }}-pam-identity
 {{- end }}

--- a/helm/opencsp-console/templates/teleport-rbac.yaml
+++ b/helm/opencsp-console/templates/teleport-rbac.yaml
@@ -1,0 +1,35 @@
+{{- if eq .Values.pam.provider "teleport" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "opencsp-console.fullname" . }}-tbot
+  labels:
+    {{- include "opencsp-console.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pam-teleport
+rules:
+  # 최초 생성용 (resourceNames 제약 못 걸어서 별도 rule)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  # 갱신용 (특정 secret만)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ include "opencsp-console.fullname" . }}-pam-identity
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "opencsp-console.fullname" . }}-tbot
+  labels:
+    {{- include "opencsp-console.labels" . | nindent 4 }}
+    app.kubernetes.io/component: pam-teleport
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.pam.teleport.serviceAccountName }}
+roleRef:
+  kind: Role
+  name: {{ include "opencsp-console.fullname" . }}-tbot
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}


### PR DESCRIPTION
## 📝 Summary

tbot sidecar와 BE 컨테이너 간 identity 파일 공유 방식을 emptyDir → K8s Secret으로 전환. UID 충돌 없이 kubelet이 Secret을 sync해 BE가 안정적으로 인증서를 읽을 수 있음.

---

## 🔗 Related Issue

Closes #65

---

## 📦 Changes

- `teleport-configmap.yaml`: tbot output destination `directory` → `kubernetes_secret`
- `_helpers.tpl`: pam-identity volume `emptyDir` → `secret(optional, defaultMode: 0440)`, tbot sidecar에서 pam-identity volumeMount 제거
- `teleport-rbac.yaml` (신규): tbot SA에 Secret create/get/update/patch 권한 Role + RoleBinding
- `Chart.yaml`: version 0.1.11

---

## 🧪 Test Plan

- [x] `helm template . --set pam.provider=teleport ...` — Role/RoleBinding 렌더 확인
- [x] tbot ConfigMap에 `type: kubernetes_secret` output 포함 확인
- [ ] be-deployment에 pam-identity가 Secret 볼륨으로 마운트됨 확인
- [x] tbot sidecar volumeMounts에 pam-identity 없음 확인

---

## 🔍 Checklist
- [x] PR title follows convention (feat/fix/chore/etc.)
- [x] No unintended changes included
- [x] No unrelated commits
- [x] PR is easy for reviewers to understand