### PR TITLE
fix(helm): tbot sidecar에 POD_NAMESPACE 환경변수 주입

### DIFF
--- a/helm/opencsp-console/templates/_helpers.tpl
+++ b/helm/opencsp-console/templates/_helpers.tpl
@@ -80,6 +80,11 @@ sidecar는 config 파일만 마운트하고, identity는 K8s API로 직접 Secre
   args:
     - start
     - --config=/etc/tbot/tbot.yaml
+  env:
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
   volumeMounts:
     - name: pam-config
       mountPath: /etc/tbot


### PR DESCRIPTION
## 📝 Summary

tbot sidecar에 Downward API 기반 `POD_NAMESPACE` 환경변수를 추가. tbot의 `kubernetes_secret` output이 올바른 네임스페이스에 Secret을 생성/갱신하는 데 필요.

---

## 🔗 Related Issue

Closes #67

---

## 📦 Changes

- `_helpers.tpl`: `pamSidecar` 헬퍼에 `POD_NAMESPACE` env (Downward API `metadata.namespace`) 추가

---

## 🧪 Test Plan

- [ ] `helm template . --set pam.provider=teleport ...` — tbot sidecar에 `POD_NAMESPACE` env 포함 확인
- [ ] 실 클러스터에서 tbot이 올바른 네임스페이스에 Secret 생성 확인

---

## 🔍 Checklist
- [x] PR title follows convention (feat/fix/chore/etc.)
- [x] No unintended changes included
- [x] No unrelated commits
- [x] PR is easy for reviewers to understand