### PR TITLE
fix(be): TshCertManager identity 파일 경로 지원 및 tsh ls 오류 처리 개선

### DIFF
--- a/be/settings.gradle.kts
+++ b/be/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "OpenConsole"
+rootProject.name = "OpenCSP"

--- a/be/src/main/java/io/hlab/opencsp/infrastructure/teleport/tsh/TshCertManager.java
+++ b/be/src/main/java/io/hlab/opencsp/infrastructure/teleport/tsh/TshCertManager.java
@@ -47,9 +47,18 @@ public class TshCertManager {
      * MFA가 필요한 환경에서는 수동으로 {@code tsh login}을 먼저 실행해야 한다.
      */
     public void ensureCert() {
+        String identityPath = configStore.get(ConfigCategory.IAM, "teleport.identity.path", 
+                                    "/var/pam/identity/identity");
+        if (!Paths.get(identityPath).toFile().exists()) {
+            throw new IllegalStateException(
+                "Teleport identity 파일이 없습니다: " + identityPath + 
+                " (tbot 사이드카가 정상 동작 중인지 확인하세요)");
+        }
+
         if (Instant.now().plusSeconds(REFRESH_MARGIN_SECONDS).isBefore(certExpiry.get())) {
             return;
         }
+
         // 인증서 파일이 이미 존재하면 수동 login으로 얻은 것으로 간주
         if (privateKeyPath().toFile().exists() && sshCertPath().toFile().exists()) {
             log.atInfo()
@@ -123,18 +132,31 @@ public class TshCertManager {
         String tshPath   = configStore.get(ConfigCategory.IAM, "teleport.tsh.path", "tsh");
         String proxyAddr = configStore.get(ConfigCategory.IAM, "teleport.proxy.url", "")
                 .replaceFirst("^https?://", "");
+        String identityPath = configStore.get(ConfigCategory.IAM, "teleport.identity.path", 
+                    "/var/pam/identity/identity");
         String cluster   = proxyHost();
         try {
             ProcessBuilder pb = new ProcessBuilder(
                     tshPath, "ls",
                     "--proxy=" + proxyAddr,
+                    "--identity=" + identityPath,
                     "--format=json",
                     "--insecure"
             );
             pb.redirectErrorStream(false);
             Process process = pb.start();
             String output   = new String(process.getInputStream().readAllBytes());
-            process.waitFor();
+            String stderr = new String(process.getErrorStream().readAllBytes());
+            int exitCode = process.waitFor();
+        
+            if (exitCode != 0) {
+                log.atWarn()
+                    .addKeyValue("hostname", hostname)
+                    .addKeyValue("exit_code", exitCode)
+                    .addKeyValue("stderr", stderr)
+                    .log("tsh ls 실패");
+                return Optional.empty();
+            }
 
             ObjectMapper mapper = new ObjectMapper();
             JsonNode nodes = mapper.readTree(output);


### PR DESCRIPTION
## 📝 Summary

tbot이 발급한 identity 파일을 `TshCertManager`가 올바르게 참조하도록 수정. `tsh ls` 실패 시 원인을 로그로 노출하고 안전하게 `Optional.empty()` 반환.

---

## 🔗 Related Issue

Closes #69

---

## 📦 Changes

- `TshCertManager.java`
  - `ensureCert()`: `teleport.identity.path` 경로의 파일 존재 여부 사전 검증
  - `tsh ls`: `--identity=<path>` 플래그 추가
  - `tsh ls`: exit code·stderr 수집, 실패 시 경고 로그 후 `Optional.empty()` 반환
- `settings.gradle.kts`: 프로젝트명 `OpenConsole` → `OpenCSP` 정정

---

## 🧪 Test Plan

- [ ] tbot identity 파일 없을 때 `ensureCert()` 호출 → `IllegalStateException` 발생 확인
- [ ] `tsh ls` 실패(잘못된 proxy 주소 등) 시 경고 로그 출력 및 `Optional.empty()` 반환 확인
- [ ] 정상 identity 파일 있을 때 `tsh ls --identity` 플래그로 노드 목록 조회 확인

---

## 🔍 Checklist
- [x] PR title follows convention (feat/fix/chore/etc.)
- [x] No unintended changes included
- [x] No unrelated commits
- [x] PR is easy for reviewers to understand