### PR TITLE
fix(helm): pam-identity Secret defaultMode 0440→0444 수정

### DIFF
--- a/helm/opencsp-console/templates/_helpers.tpl
+++ b/helm/opencsp-console/templates/_helpers.tpl
@@ -116,7 +116,7 @@ teleport 모드:
 - name: pam-identity
   secret:
     secretName: {{ include "opencsp-console.fullname" . }}-pam-identity
-    defaultMode: 0440
+    defaultMode: 0444
     optional: true
 - name: pam-config
   configMap:


### PR DESCRIPTION
## 📝 Summary

BE 컨테이너가 tbot과 UID가 달라 `defaultMode: 0440`(other 권한 없음)으로는 identity Secret 파일을 읽지 못하는 문제 수정. `0444`로 변경해 모든 컨테이너에서 읽기 가능하도록 함.

---

## 🔗 Related Issue

Closes #70

---

## 📦 Changes

- `_helpers.tpl`: `pamVolumes` 헬퍼의 `pam-identity` Secret `defaultMode` `0440` → `0444`

---

## 🧪 Test Plan

- [ ] `helm template . --set pam.provider=teleport ...` — `defaultMode: 292`(0444) 렌더 확인
- [ ] 실 클러스터에서 BE 컨테이너가 마운트된 identity 파일 읽기 성공 확인

---

## 🔍 Checklist
- [x] PR title follows convention (feat/fix/chore/etc.)
- [x] No unintended changes included
- [x] No unrelated commits
- [x] PR is easy for reviewers to understand