### PR TITLE
fix(be): tsh ssh 릴레이에 identity 파일 전달 및 불필요한 cert 관리 로직 제거

### DIFF
--- a/be/src/main/java/io/hlab/opencsp/infrastructure/teleport/tsh/TshCertManager.java
+++ b/be/src/main/java/io/hlab/opencsp/infrastructure/teleport/tsh/TshCertManager.java
@@ -54,22 +54,6 @@ public class TshCertManager {
                 "Teleport identity 파일이 없습니다: " + identityPath + 
                 " (tbot 사이드카가 정상 동작 중인지 확인하세요)");
         }
-
-        if (Instant.now().plusSeconds(REFRESH_MARGIN_SECONDS).isBefore(certExpiry.get())) {
-            return;
-        }
-
-        // 인증서 파일이 이미 존재하면 수동 login으로 얻은 것으로 간주
-        if (privateKeyPath().toFile().exists() && sshCertPath().toFile().exists()) {
-            log.atInfo()
-                    .addKeyValue("key_path", privateKeyPath().toString())
-                    .addKeyValue("cert_path", sshCertPath().toString())
-                    .log("기존 인증서 파일 사용");
-            certExpiry.set(Instant.now().plusSeconds(3600));
-            return;
-        }
-        // 파일 없으면 tsh login 시도 (MFA 없는 환경 또는 TSH_PASSWORD 환경변수 설정된 경우)
-        refreshCert();
     }
 
     /**

--- a/be/src/main/java/io/hlab/opencsp/infrastructure/teleport/tsh/TshCertManager.java
+++ b/be/src/main/java/io/hlab/opencsp/infrastructure/teleport/tsh/TshCertManager.java
@@ -82,6 +82,11 @@ public class TshCertManager {
         return configStore.get(ConfigCategory.IAM, "teleport.tsh.path", "tsh");
     }
 
+    /** tbot identity 파일 경로 */
+    public String identityPath() {
+        return configStore.get(ConfigCategory.IAM, "teleport.identity.path", "/var/pam/identity/identity");
+    }
+
     /** tsh --proxy 인수용 주소 (host:port) */
     public String proxyAddr() {
         return proxyHost() + ":" + sshProxyPort();

--- a/be/src/main/java/io/hlab/opencsp/infrastructure/teleport/tsh/TshSshSession.java
+++ b/be/src/main/java/io/hlab/opencsp/infrastructure/teleport/tsh/TshSshSession.java
@@ -41,10 +41,12 @@ public class TshSshSession implements Closeable {
      * @param login     SSH 로그인 계정 (root 등)
      */
     public static TshSshSession connect(
-            String tshPath, String proxyAddr, String nodeId, String login) throws IOException {
+        String tshPath, String proxyAddr, String identityPath,
+        String nodeId, String login) throws IOException {
 
         log.atInfo()
                 .addKeyValue("proxy_addr", proxyAddr)
+                .addKeyValue("identity_path", identityPath)
                 .addKeyValue("teleport_node_id", nodeId)
                 .addKeyValue("ssh_login", login)
                 .log("tsh ssh 실행");
@@ -52,6 +54,7 @@ public class TshSshSession implements Closeable {
         ProcessBuilder pb = new ProcessBuilder(
                 tshPath, "ssh",
                 "--proxy=" + proxyAddr,
+                "--identity=" + identityPath,
                 "--insecure",
                 "--no-resume",
                 login + "@" + nodeId

--- a/be/src/main/java/io/hlab/opencsp/infrastructure/teleport/websocket/ConsoleWebSocketHandler.java
+++ b/be/src/main/java/io/hlab/opencsp/infrastructure/teleport/websocket/ConsoleWebSocketHandler.java
@@ -88,6 +88,7 @@ public class ConsoleWebSocketHandler extends AbstractWebSocketHandler {
                 TshSshSession ssh = TshSshSession.connect(
                         tshCertManager.tshPath(),
                         tshCertManager.proxyAddr(),
+                        tshCertManager.identityPath(),
                         consoleSession.getTeleportNodeId(),
                         consoleSession.getTeleportLogin()
                 );


### PR DESCRIPTION
## 📝 Summary

tbot이 발급한 identity 파일을 `tsh ssh`에 전달하지 않아 릴레이 연결이 실패하던 문제 수정.
`ensureCert()`의 수동 cert fallback 로직도 tbot 구조와 충돌하여 제거.

---

## 🔗 Related Issue

Closes #73

---

## 📦 Changes

- `TshSshSession.java`: `connect()`에 `identityPath` 파라미터 추가, `--identity=<path>` 플래그 전달, 로그에 `identity_path` 추가
- `TshCertManager.java`: `ensureCert()`에서 cert 만료 체크·수동 cert 파일 fallback·`refreshCert()` 호출 블록 제거

---

## 🧪 Test Plan

- [ ] `tsh ssh` 실행 시 `--identity` 플래그 포함 확인
- [ ] tbot identity 파일 없을 때 `ensureCert()` → `IllegalStateException` 발생 확인
- [ ] 정상 identity 파일 있을 때 tsh ssh 릴레이 연결 성공 확인

---

## 🔍 Checklist
- [x] PR title follows convention (feat/fix/chore/etc.)
- [x] No unintended changes included
- [x] No unrelated commits
- [x] PR is easy for reviewers to understand